### PR TITLE
Use sdk for branch logic

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -14,11 +14,7 @@ const sdk = new ValTown({
  * @throws {Error} Error if the default branch is not found
  */
 async function defaultBranchId(projectId: string): Promise<string> {
-  for await (const branch of sdk.projects.branches.list(projectId, {})) {
-    if (branch.name == DEFAULT_BRANCH_NAME) return branch.id;
-  }
-
-  throw new Error(`Branch "${DEFAULT_BRANCH_NAME}" not found`);
+  return await getMainBranchId(projectId);
 }
 
 /**
@@ -33,34 +29,11 @@ async function branchIdToName(
   projectId: string,
   branchName: string,
 ): Promise<string> {
-  // Because of a val town bug (see
-  // https://www.val.town/v/wolf/ecstaticPeachRat), only unauthenticated
-  // requests can query data on val town branches.
-  //
-  // TODO: change this to use branch alias API when it gets added
-
-  const response = await fetch(
-    `https://api.val.town/v1/projects/${projectId}/branches?limit=100`,
-  );
-
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch branches: ${response.status} ${response.statusText}`,
-    );
+  for await (const branch of sdk.projects.branches.list(projectId, {})) {
+    if (branch.name == branchName) return branch.id;
   }
 
-  const data = await response.json();
-
-  // deno-lint-ignore no-explicit-any
-  const branch = data.data.find((b: any) => b.name === branchName);
-
-  if (!branch) {
-    throw new Error(
-      `Branch "${branchName}" not found in project "${projectId}"`,
-    );
-  }
-
-  return branch.id;
+  throw new Error(`Branch "${branchName}" not found in project ${projectId}`);
 }
 
 /**


### PR DESCRIPTION
The bug in Val Town's API was fixed where you could only list branches for projects that had forked branches when making unauthenticated requests. This reverts the manual logic to get around this bug back to using the official sdk.