### PR TITLE
Run ci on every commit push

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,6 @@
 name: VT Testing
 
-on: [pull_request]
+on: [push]
 
 jobs:
   test:


### PR DESCRIPTION
I typically prefer this, runs things faster and we'll get runs in more places. 