### PR TITLE
Fix hyphen jsdoc consistency

### DIFF
--- a/src/cmd/parsing.ts
+++ b/src/cmd/parsing.ts
@@ -2,8 +2,8 @@
  * Parses a project URI, either username/projectName, projectName (with
  * defaulted username), or `https://www.val.town/x/username/exampleProject`.
  *
- * @param {string} projectUri The project URI, either a URL or a project URI.
- * @param {string} currentUsername The fallback username, if the project URI doesn't specify.
+ * @param {string} projectUri - The project URI, either a URL or a project URI.
+ * @param {string} currentUsername - The fallback username, if the project URI doesn't specify.
  * @returns The ownerName and projectName extracted from the input.
  * @throws An error if the input format is invalid.
  */

--- a/src/cmd/styling.ts
+++ b/src/cmd/styling.ts
@@ -7,8 +7,8 @@ export const success = colors.bold.green;
 /**
  * Formats a file path with a colored status prefix for display.
  *
- * @param {string} path The file or directory path to format
- * @param {string} status The status string that determines the prefix and color
+ * @param {string} path - The file or directory path to format
+ * @param {string} status - The status string that determines the prefix and color
  * @returns {string} A formatted string with colored prefix and path
  */
 export function formatStatus(path: string, status: string): string {

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -1,5 +1,3 @@
-import type VTClient from "~/vt/vt/VTClient.ts";
-
 /**
  * Gets active directory path, either from the provided directory or the
  * current working directory.

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -9,8 +9,8 @@ const sdk = new ValTown({
 /**
  * Converts a branch name to its corresponding branch ID for a given project.
  *
- * @param {string} projectId The ID of the project containing the branch
- * @param {string} branchName The name of the branch to look up
+ * @param {string} projectId - The ID of the project containing the branch
+ * @param {string} branchName - The name of the branch to look up
  * @returns {Promise} Promise resolving to the branch ID
  * @throws {Error} if the branch is not found or if the API request fails
  */

--- a/src/vt/git/checkout.ts
+++ b/src/vt/git/checkout.ts
@@ -26,11 +26,11 @@ type ForkCheckoutParams = BaseCheckoutParams & {
  * does nothing if it fails.
  *
  * @param {object} args
- * @param {string} args.targetDir The directory where the branch will be checked out.
- * @param {string} args.projectId The ID of the project.
- * @param {string} args.branchId The ID of the branch to checkout.
- * @param {number} args.version The version of the branch to checkout.
- * @param {string[]} args.ignoreGlobs List of glob patterns for files to ignore during checkout.
+ * @param {string} args.targetDir - The directory where the branch will be checked out.
+ * @param {string} args.projectId - The ID of the project.
+ * @param {string} args.branchId - The ID of the branch to checkout.
+ * @param {number} args.version - The version of the branch to checkout.
+ * @param {string[]} args.ignoreGlobs - List of glob patterns for files to ignore during checkout.
  * @returns {Promise<void>} A promise that resolves when the branch checkout is complete.
  */
 export function checkout(args: BranchCheckoutParams): Promise<undefined>;
@@ -40,12 +40,12 @@ export function checkout(args: BranchCheckoutParams): Promise<undefined>;
  * operation that does nothing if it fails.
  *
  * @param {object} args
- * @param {string} args.targetDir The directory where the fork will be checked out.
- * @param {string} args.projectId The ID of the project to fork.
- * @param {string} args.forkedFrom The branch ID from which to create the fork.
- * @param {string} args.name The name for the new forked branch.
- * @param {number} args.version The version of the fork to checkout.
- * @param {string[]} args.ignoreGlobs List of glob patterns for files to ignore during checkout.
+ * @param {string} args.targetDir - The directory where the fork will be checked out.
+ * @param {string} args.projectId - The ID of the project to fork.
+ * @param {string} args.forkedFrom - The branch ID from which to create the fork.
+ * @param {string} args.name - The name for the new forked branch.
+ * @param {number} args.version - The version of the fork to checkout.
+ * @param {string[]} args.ignoreGlobs - List of glob patterns for files to ignore during checkout.
  * @returns {Promise<void>} A promise that resolves when the fork checkout is complete.
  */
 export function checkout(

--- a/src/vt/git/clone.ts
+++ b/src/vt/git/clone.ts
@@ -13,11 +13,11 @@ import { doAtomically } from "~/vt/git/utils.ts";
  * target directory.
  *
  * @param {object} args
- * @param {string} args.targetDir The directory where the project will be cloned
- * @param {string} args.projectId The uuid of the project to be cloned
- * @param {string} args.branchId (optional) The branch ID to clone.
- * @param {number} args.version (optional) The version of the project to clone.
- * @param {string[]} args.ignoreGlobs (optional) List of glob patterns for files to ignore
+ * @param {string} args.targetDir - The directory where the project will be cloned
+ * @param {string} args.projectId - The uuid of the project to be cloned
+ * @param {string} [args.branchId] - The branch ID to clone.
+ * @param {number} [args.version] - The version of the project to clone.
+ * @param {string[]} [args.ignoreGlobs] - List of glob patterns for files to ignore
  */
 export function clone(
   {

--- a/src/vt/git/paths.ts
+++ b/src/vt/git/paths.ts
@@ -4,9 +4,9 @@ import { VAL_TYPE_EXTENSIONS } from "~/consts.ts";
 /**
  * Adds val file extension to a filename
  *
- * @param filename Base filename
- * @param type Val file type (script, http, ...)
- * @param abbreviated Whether to use val file extension (default: false)
+ * @param filename - Base filename
+ * @param type - Val file type (script, http, ...)
+ * @param [abbreviated] - Whether to use val file extension (default: false)
  * @returns Filename with val file extension
  */
 function withValExtension(

--- a/src/vt/git/pull.ts
+++ b/src/vt/git/pull.ts
@@ -7,10 +7,10 @@ import { doAtomically } from "~/vt/git/utils.ts";
  * Pulls latest changes from a val town project into a vt folder.
  *
  * @param args Options for pull operation.
- * @param {string} args.targetDir The vt project root directory.
- * @param {string} args.projectId The id of the project to be pulled.
- * @param {string} args.branchId The branch ID from which to pull the latest changes.
- * @param {string[]} args.ignoreGlobs A list of glob patterns for files to exclude.
+ * @param {string} args.targetDir - The vt project root directory.
+ * @param {string} args.projectId - The id of the project to be pulled.
+ * @param {string} args.branchId - The branch ID from which to pull the latest changes.
+ * @param {string[]} args.ignoreGlobs - A list of glob patterns for files to exclude.
  *
  * @returns Promise that resolves when the pull operation is complete.
  */

--- a/src/vt/git/status.ts
+++ b/src/vt/git/status.ts
@@ -25,11 +25,11 @@ export interface StatusResult {
  * modified, deleted, or created.
  *
  * @param args Options for status operation.
- * @param {string} args.targetDir The directory to scan for changes.
- * @param {string} args.projectId The Val Town project ID.
- * @param {string} args.branchId Optional branch ID to check against.
- * @param {string} args.version The version to check the status against.
- * @param {string} args.ignoreGlobs Glob patterns for files to ignore.
+ * @param {string} args.targetDir - The directory to scan for changes.
+ * @param {string} args.projectId - The Val Town project ID.
+ * @param {string} args.branchId - Optional branch ID to check against.
+ * @param {string} args.version - The version to check the status against.
+ * @param {string} args.ignoreGlobs - Glob patterns for files to ignore.
  *
  * @returns Promise that resolves to a StatusResult object containing categorized files.
  */

--- a/src/vt/git/utils.ts
+++ b/src/vt/git/utils.ts
@@ -6,7 +6,7 @@ import { copy, ensureDir } from "@std/fs";
 /**
  * Creates a temporary directory and returns it with a cleanup function.
  *
- * @param {string} prefix Optional prefix for the temporary directory name
+ * @param {string} [prefix] - Optional prefix for the temporary directory name
  * @returns Promise that resolves to temporary directory path and cleanup function
  */
 export async function withTempDir(
@@ -30,7 +30,7 @@ export async function withTempDir(
  * Create a directory atomically by first doing logic to create it in a temp
  * directory, and then moving it to a destination afterwards.
  *
- * @param {string} targetDir The directory to eventually send the output to.
+ * @param {string} targetDir - The directory to eventually send the output to.
  */
 export async function doAtomically<T>(
   op: (tmpDir: string) => Promise<T>,
@@ -56,8 +56,8 @@ export async function doAtomically<T>(
 /**
  * Removes contents from a directory while respecting ignore patterns.
  *
- * @param {string} directory Directory path to clean
- * @param {string[]} ignoreGlobs Glob patterns for files to ignore
+ * @param {string} directory - Directory path to clean
+ * @param {string[]} ignoreGlobs - Glob patterns for files to ignore
  */
 export async function cleanDirectory(
   directory: string,
@@ -80,7 +80,7 @@ export async function cleanDirectory(
 /**
  * Check if the target directory is dirty (has unpushed local changes).
  *
- * @param {StatusResult} statusResult Result of a status operation.
+ * @param {StatusResult} statusResult - Result of a status operation.
  */
 export function isDirty(statusResult: StatusResult): boolean {
   return statusResult.modified.length > 0;


### PR DESCRIPTION
Pretty simple, just add -s between parameters for all the jsdocs. We could also not use hyphens but it's been inconsistent.