### PR TITLE
Make http importable

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -8,20 +8,5 @@
     "fmt:check": "deno fmt --check"
   },
   "imports": {
-    "@cliffy/ansi": "jsr:@cliffy/ansi@^1.0.0-rc.7",
-    "@cliffy/table": "jsr:@cliffy/table@1.0.0-rc.7",
-    "@deno-library/logger": "jsr:@deno-library/logger@^1.1.9",
-    "@std/async": "jsr:@std/async@^1.0.11",
-    "@std/fs": "jsr:@std/fs@^1.0.13",
-    "@std/path": "jsr:@std/path@^1.0.8",
-    "zod": "npm:zod@^3.24.2",
-    "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",
-    "@std/assert": "jsr:@std/assert@1",
-    "@std/dotenv": "jsr:@std/dotenv@^0.225.3",
-    "@std/encoding": "jsr:@std/encoding@^1.0.7",
-    "@valtown/sdk": "jsr:@valtown/sdk@^0.36.0",
-    "emphasize": "npm:emphasize@^7.0.0",
-    "highlight.js": "npm:highlight.js@^11.11.1",
-    "kia": "https://deno.land/x/kia@0.4.1/mod.ts"
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -15,7 +15,6 @@
     "@std/fs": "jsr:@std/fs@^1.0.13",
     "@std/path": "jsr:@std/path@^1.0.8",
     "zod": "npm:zod@^3.24.2",
-    "~/": "./src/",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.7",
     "@std/assert": "jsr:@std/assert@1",
     "@std/dotenv": "jsr:@std/dotenv@^0.225.3",

--- a/deno.lock
+++ b/deno.lock
@@ -6,35 +6,24 @@
     "jsr:@cliffy/flags@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/internal@1.0.0-rc.7": "1.0.0-rc.7",
     "jsr:@cliffy/table@1.0.0-rc.7": "1.0.0-rc.7",
-    "jsr:@deno-library/logger@^1.1.9": "1.1.9",
     "jsr:@std/assert@1": "1.0.11",
     "jsr:@std/async@*": "1.0.11",
     "jsr:@std/async@^1.0.11": "1.0.11",
     "jsr:@std/dotenv@~0.225.3": "0.225.3",
-    "jsr:@std/encoding@^1.0.7": "1.0.7",
-    "jsr:@std/encoding@~1.0.5": "1.0.7",
-    "jsr:@std/fmt@1.0.3": "1.0.3",
     "jsr:@std/fmt@~1.0.2": "1.0.6",
     "jsr:@std/fs@^1.0.13": "1.0.14",
-    "jsr:@std/fs@^1.0.6": "1.0.14",
     "jsr:@std/internal@^1.0.5": "1.0.5",
-    "jsr:@std/io@~0.224.9": "0.224.9",
     "jsr:@std/path@^1.0.8": "1.0.8",
     "jsr:@std/text@~1.0.7": "1.0.11",
     "jsr:@valtown/sdk@0.36": "0.36.0",
     "npm:@types/node@*": "22.12.0",
-    "npm:emphasize@7": "7.0.0",
-    "npm:highlight.js@^11.11.1": "11.11.1",
     "npm:zod@^3.24.2": "3.24.2"
   },
   "jsr": {
     "@cliffy/ansi@1.0.0-rc.7": {
       "integrity": "f71c921cce224c13d322e5cedba4f38e8f7354c7d855c9cb22729362a53f25aa",
       "dependencies": [
-        "jsr:@cliffy/internal",
-        "jsr:@std/encoding@~1.0.5",
-        "jsr:@std/fmt@~1.0.2",
-        "jsr:@std/io"
+        "jsr:@std/fmt"
       ]
     },
     "@cliffy/command@1.0.0-rc.7": {
@@ -43,7 +32,7 @@
         "jsr:@cliffy/flags",
         "jsr:@cliffy/internal",
         "jsr:@cliffy/table",
-        "jsr:@std/fmt@~1.0.2",
+        "jsr:@std/fmt",
         "jsr:@std/text"
       ]
     },
@@ -59,14 +48,7 @@
     "@cliffy/table@1.0.0-rc.7": {
       "integrity": "9fdd9776eda28a0b397981c400eeb1aa36da2371b43eefe12e6ff555290e3180",
       "dependencies": [
-        "jsr:@std/fmt@~1.0.2"
-      ]
-    },
-    "@deno-library/logger@1.1.9": {
-      "integrity": "f7d7347b3bdf85dd3692b501bb27b11d685c53efd90a07bc6a4d6edd01f8511b",
-      "dependencies": [
-        "jsr:@std/fmt@1.0.3",
-        "jsr:@std/fs@^1.0.6"
+        "jsr:@std/fmt"
       ]
     },
     "@std/assert@1.0.11": {
@@ -81,12 +63,6 @@
     "@std/dotenv@0.225.3": {
       "integrity": "a95e5b812c27b0854c52acbae215856d9cce9d4bbf774d938c51d212711e8d4a"
     },
-    "@std/encoding@1.0.7": {
-      "integrity": "f631247c1698fef289f2de9e2a33d571e46133b38d042905e3eac3715030a82d"
-    },
-    "@std/fmt@1.0.3": {
-      "integrity": "97765c16aa32245ff4e2204ecf7d8562496a3cb8592340a80e7e554e0bb9149f"
-    },
     "@std/fmt@1.0.6": {
       "integrity": "a2c56a69a2369876ddb3ad6a500bb6501b5bad47bb3ea16bfb0c18974d2661fc"
     },
@@ -99,9 +75,6 @@
     "@std/internal@1.0.5": {
       "integrity": "54a546004f769c1ac9e025abd15a76b6671ddc9687e2313b67376125650dc7ba"
     },
-    "@std/io@0.224.9": {
-      "integrity": "4414664b6926f665102e73c969cfda06d2c4c59bd5d0c603fd4f1b1c840d6ee3"
-    },
     "@std/path@1.0.8": {
       "integrity": "548fa456bb6a04d3c1a1e7477986b6cffbce95102d0bb447c67c4ee70e0364be"
     },
@@ -113,54 +86,10 @@
     }
   },
   "npm": {
-    "@types/hast@3.0.4": {
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
-      "dependencies": [
-        "@types/unist"
-      ]
-    },
     "@types/node@22.12.0": {
       "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "dependencies": [
         "undici-types"
-      ]
-    },
-    "@types/unist@3.0.3": {
-      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="
-    },
-    "chalk@5.4.1": {
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="
-    },
-    "dequal@2.0.3": {
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
-    },
-    "devlop@1.1.0": {
-      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dependencies": [
-        "dequal"
-      ]
-    },
-    "emphasize@7.0.0": {
-      "integrity": "sha512-jdFCDyt+YetBXO12VwK4AiLsMCvkZ3IBxMVIJddB+25EwIL0VETBgpvPkJl63+JyAgaQ5Wja10qWMoXXC95JNg==",
-      "dependencies": [
-        "@types/hast",
-        "chalk",
-        "highlight.js@11.9.0",
-        "lowlight"
-      ]
-    },
-    "highlight.js@11.11.1": {
-      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="
-    },
-    "highlight.js@11.9.0": {
-      "integrity": "sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw=="
-    },
-    "lowlight@3.1.0": {
-      "integrity": "sha512-CEbNVoSikAxwDMDPjXlqlFYiZLkDJHwyGu/MfOsJnF3d7f3tds5J3z8s/l9TMXhzfsJCCJEAsD78842mwmg0PQ==",
-      "dependencies": [
-        "@types/hast",
-        "devlop",
-        "highlight.js@11.9.0"
       ]
     },
     "undici-types@6.20.0": {
@@ -192,23 +121,5 @@
     "https://deno.land/x/kia@0.4.1/mod.ts": "727b60e707c46429e40a2159ab73381245ef08a8e1e59e1e5a705745b99f4aec",
     "https://deno.land/x/kia@0.4.1/spinners.ts": "26b63f964c745d6cc46e547d98352a4f64ae6d28400d35d9b77be7a5141db860",
     "https://deno.land/x/kia@0.4.1/util.ts": "b7ac0962b5a39f666bad41c8b93efe1ea599fbac05ea9f65c0409926e8092618"
-  },
-  "workspace": {
-    "dependencies": [
-      "jsr:@cliffy/ansi@^1.0.0-rc.7",
-      "jsr:@cliffy/command@^1.0.0-rc.7",
-      "jsr:@cliffy/table@1.0.0-rc.7",
-      "jsr:@deno-library/logger@^1.1.9",
-      "jsr:@std/assert@1",
-      "jsr:@std/async@^1.0.11",
-      "jsr:@std/dotenv@~0.225.3",
-      "jsr:@std/encoding@^1.0.7",
-      "jsr:@std/fs@^1.0.13",
-      "jsr:@std/path@^1.0.8",
-      "jsr:@valtown/sdk@0.36",
-      "npm:emphasize@7",
-      "npm:highlight.js@^11.11.1",
-      "npm:zod@^3.24.2"
-    ]
   }
 }

--- a/src/cmd/git.ts
+++ b/src/cmd/git.ts
@@ -1,16 +1,16 @@
-import { Command } from "@cliffy/command";
+import { Command } from "jsr:@cliffy/command@^1.0.0-rc.7";
 import sdk, { branchNameToId, user } from "../sdk.ts";
 import { DEFAULT_BRANCH_NAME, DEFAULT_IGNORE_PATTERNS } from "../consts.ts";
 import { parseProjectUri } from "../cmd/parsing.ts";
 import VTClient from "../vt/vt/VTClient.ts";
-import Kia from "kia";
+import Kia from "https://deno.land/x/kia@0.4.1/mod.ts";
 import { checkDirectory } from "../utils.ts";
-import { basename } from "@std/path";
+import { basename } from "jsr:@std/path@^1.0.8";
 import * as styles from "./styling.ts";
-import * as join from "@std/path/join";
-import { colors } from "@cliffy/ansi/colors";
-import { Table } from "@cliffy/table";
-import ValTown from "@valtown/sdk";
+import * as join from "jsr:@std/path@^1.0.8/join";
+import { colors } from "jsr:@cliffy/ansi@^1.0.0-rc.7/colors";
+import { Table } from "jsr:@cliffy/table@1.0.0-rc.7";
+import ValTown from "jsr:@valtown/sdk@^0.36.0";
 
 const cloneCmd = new Command()
   .name("clone")

--- a/src/cmd/git.ts
+++ b/src/cmd/git.ts
@@ -1,12 +1,12 @@
 import { Command } from "@cliffy/command";
-import sdk, { branchNameToId, user } from "~/sdk.ts";
-import { DEFAULT_BRANCH_NAME, DEFAULT_IGNORE_PATTERNS } from "~/consts.ts";
-import { parseProjectUri } from "~/cmd/parsing.ts";
-import VTClient from "~/vt/vt/VTClient.ts";
+import sdk, { branchNameToId, user } from "../sdk.ts";
+import { DEFAULT_BRANCH_NAME, DEFAULT_IGNORE_PATTERNS } from "../consts.ts";
+import { parseProjectUri } from "../cmd/parsing.ts";
+import VTClient from "../vt/vt/VTClient.ts";
 import Kia from "kia";
-import { checkDirectory } from "~/utils.ts";
+import { checkDirectory } from "../utils.ts";
 import { basename } from "@std/path";
-import * as styles from "~/cmd/styling.ts";
+import * as styles from "./styling.ts";
 import * as join from "@std/path/join";
 import { colors } from "@cliffy/ansi/colors";
 import { Table } from "@cliffy/table";

--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -1,12 +1,12 @@
 import { Command } from "@cliffy/command";
 import manifest from "../../deno.json" with { type: "json" };
-import * as cmds from "~/cmd/git.ts";
-import { watchCmd } from "~/cmd/watch.ts";
-import VTClient from "~/vt/vt/VTClient.ts";
+import * as cmds from "./git.ts";
+import { watchCmd } from "./watch.ts";
+import VTClient from "../vt/vt/VTClient.ts";
 import { basename, join } from "@std/path";
-import { user } from "~/sdk.ts";
-import { checkDirectory } from "~/utils.ts";
-import { DEFAULT_IGNORE_PATTERNS } from "~/consts.ts";
+import { user } from "../sdk.ts";
+import { checkDirectory } from "../utils.ts";
+import { DEFAULT_IGNORE_PATTERNS } from "../consts.ts";
 import Kia from "kia";
 import { APIError } from "@valtown/sdk";
 

--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -1,14 +1,14 @@
-import { Command } from "@cliffy/command";
+import { Command } from "jsr:@cliffy/command@^1.0.0-rc.7";
 import manifest from "../../deno.json" with { type: "json" };
 import * as cmds from "./git.ts";
 import { watchCmd } from "./watch.ts";
 import VTClient from "../vt/vt/VTClient.ts";
-import { basename, join } from "@std/path";
+import { basename, join } from "jsr:@std/path@^1.0.8";
 import { user } from "../sdk.ts";
 import { checkDirectory } from "../utils.ts";
 import { DEFAULT_IGNORE_PATTERNS } from "../consts.ts";
-import Kia from "kia";
-import { APIError } from "@valtown/sdk";
+import Kia from "https://deno.land/x/kia@0.4.1/mod.ts";
+import { APIError } from "jsr:@valtown/sdk@^0.36.0";
 
 const cmd = new Command()
   .name("vt")

--- a/src/cmd/styling.ts
+++ b/src/cmd/styling.ts
@@ -1,4 +1,4 @@
-import { colors } from "@cliffy/ansi/colors";
+import { colors } from "jsr:@cliffy/ansi@^1.0.0-rc.7/colors";
 import { STATUS_COLORS } from "../consts.ts";
 
 export const error = colors.bold.red;

--- a/src/cmd/styling.ts
+++ b/src/cmd/styling.ts
@@ -1,5 +1,5 @@
 import { colors } from "@cliffy/ansi/colors";
-import { STATUS_COLORS } from "~/consts.ts";
+import { STATUS_COLORS } from "../consts.ts";
 
 export const error = colors.bold.red;
 export const success = colors.bold.green;

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -1,4 +1,3 @@
-import type VTClient from "~/vt/vt/VTClient.ts";
 
 /**
  * Gets active directory path, either from the provided directory or the

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -1,4 +1,3 @@
-
 /**
  * Gets active directory path, either from the provided directory or the
  * current working directory.

--- a/src/cmd/watch.ts
+++ b/src/cmd/watch.ts
@@ -1,6 +1,6 @@
 import { Command } from "@cliffy/command";
 import Kia from "kia";
-import VTClient from "~/vt/vt/VTClient.ts";
+import VTClient from "../vt/vt/VTClient.ts";
 
 export const watchStopCmd = new Command()
   .name("watch stop")

--- a/src/cmd/watch.ts
+++ b/src/cmd/watch.ts
@@ -1,5 +1,5 @@
-import { Command } from "@cliffy/command";
-import Kia from "kia";
+import { Command } from "jsr:@cliffy/command@^1.0.0-rc.7";
+import Kia from "https://deno.land/x/kia@0.4.1/mod.ts";
 import VTClient from "../vt/vt/VTClient.ts";
 
 export const watchStopCmd = new Command()

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,4 +1,5 @@
-import { colors } from "@cliffy/ansi/colors";
+import { colors } from "jsr:@cliffy/ansi@^1.0.0-rc.7/colors";
+
 
 export const DEFAULT_BRANCH_NAME = "main";
 export const API_KEY_KEY = "VAL_TOWN_API_KEY";

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,6 +1,5 @@
 import { colors } from "jsr:@cliffy/ansi@^1.0.0-rc.7/colors";
 
-
 export const DEFAULT_BRANCH_NAME = "main";
 export const API_KEY_KEY = "VAL_TOWN_API_KEY";
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,5 +1,5 @@
-import ValTown from "@valtown/sdk";
-import "@std/dotenv/load";
+import ValTown from "jsr:@valtown/sdk@^0.36.0";
+import "jsr:@std/dotenv@^0.225.3/load";
 import { API_KEY_KEY } from "./consts.ts";
 
 const sdk = new ValTown({

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,6 +1,6 @@
 import ValTown from "@valtown/sdk";
 import "@std/dotenv/load";
-import { API_KEY_KEY } from "~/consts.ts";
+import { API_KEY_KEY } from "./consts.ts";
 
 const sdk = new ValTown({
   bearerToken: Deno.env.get(API_KEY_KEY)!,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
-import { basename, globToRegExp } from "@std/path";
+import { basename, globToRegExp } from "jsr:@std/path@^1.0.8";
+
 
 export async function isDirectoryEmpty(
   path: string | URL,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
 import { basename, globToRegExp } from "jsr:@std/path@^1.0.8";
 
-
 export async function isDirectoryEmpty(
   path: string | URL,
   ignoreGlobs: string[] = [],

--- a/src/vt/git/checkout.ts
+++ b/src/vt/git/checkout.ts
@@ -1,8 +1,8 @@
 import { cleanDirectory, doAtomically } from "./utils.ts";
 import { clone } from "./clone.ts";
 import sdk from "../../sdk.ts";
-import { copy } from "@std/fs";
-import ValTown from "@valtown/sdk";
+import { copy } from "jsr:@std/fs@^1.0.13";
+import ValTown from "jsr:@valtown/sdk@^0.36.0";
 
 type BaseCheckoutParams = {
   targetDir: string;

--- a/src/vt/git/checkout.ts
+++ b/src/vt/git/checkout.ts
@@ -1,6 +1,6 @@
-import { cleanDirectory, doAtomically } from "~/vt/git/utils.ts";
-import { clone } from "~/vt/git/clone.ts";
-import sdk from "~/sdk.ts";
+import { cleanDirectory, doAtomically } from "./utils.ts";
+import { clone } from "./clone.ts";
+import sdk from "../../sdk.ts";
 import { copy } from "@std/fs";
 import ValTown from "@valtown/sdk";
 

--- a/src/vt/git/clone.ts
+++ b/src/vt/git/clone.ts
@@ -1,10 +1,10 @@
 import sdk from "../../sdk.ts";
-import type Valtown from "@valtown/sdk";
+import type Valtown from "jsr:@valtown/sdk@^0.36.0";
 import { removeEmptyDirs } from "../../utils.ts";
 import { shouldIgnore } from "./paths.ts";
-import * as path from "@std/path";
-import { ensureDir } from "@std/fs";
-import type ValTown from "@valtown/sdk";
+import * as path from "jsr:@std/path@^1.0.8";
+import { ensureDir } from "jsr:@std/fs@^1.0.13";
+import type ValTown from "jsr:@valtown/sdk@^0.36.0";
 import { doAtomically } from "./utils.ts";
 
 /**

--- a/src/vt/git/clone.ts
+++ b/src/vt/git/clone.ts
@@ -1,11 +1,11 @@
-import sdk from "~/sdk.ts";
+import sdk from "../../sdk.ts";
 import type Valtown from "@valtown/sdk";
-import { removeEmptyDirs } from "~/utils.ts";
-import { shouldIgnore } from "~/vt/git/paths.ts";
+import { removeEmptyDirs } from "../../utils.ts";
+import { shouldIgnore } from "./paths.ts";
 import * as path from "@std/path";
 import { ensureDir } from "@std/fs";
 import type ValTown from "@valtown/sdk";
-import { doAtomically } from "~/vt/git/utils.ts";
+import { doAtomically } from "./utils.ts";
 
 /**
  * Clones a project by downloading its files and directories to the specified

--- a/src/vt/git/paths.ts
+++ b/src/vt/git/paths.ts
@@ -1,4 +1,4 @@
-import * as path from "@std/path";
+import * as path from "jsr:@std/path@^1.0.8";
 import { DEFAULT_VAL_TYPE, ProjectItem } from "../../consts.ts";
 import { filePathToFile } from "../../sdk.ts";
 

--- a/src/vt/git/paths.ts
+++ b/src/vt/git/paths.ts
@@ -1,6 +1,6 @@
 import * as path from "@std/path";
-import { DEFAULT_VAL_TYPE, ProjectItem } from "~/consts.ts";
-import { filePathToFile } from "~/sdk.ts";
+import { DEFAULT_VAL_TYPE, ProjectItem } from "../../consts.ts";
+import { filePathToFile } from "../../sdk.ts";
 
 /**
  * Determine the type of a project file.

--- a/src/vt/git/pull.ts
+++ b/src/vt/git/pull.ts
@@ -1,6 +1,6 @@
 import { clone } from "./clone.ts";
 import { status } from "./status.ts";
-import * as path from "@std/path";
+import * as path from "jsr:@std/path@^1.0.8";
 import { doAtomically } from "./utils.ts";
 
 /**

--- a/src/vt/git/pull.ts
+++ b/src/vt/git/pull.ts
@@ -1,7 +1,7 @@
-import { clone } from "~/vt/git/clone.ts";
-import { status } from "~/vt/git/status.ts";
+import { clone } from "./clone.ts";
+import { status } from "./status.ts";
 import * as path from "@std/path";
-import { doAtomically } from "~/vt/git/utils.ts";
+import { doAtomically } from "./utils.ts";
 
 /**
  * Pulls latest changes from a val town project into a vt folder.

--- a/src/vt/git/push.ts
+++ b/src/vt/git/push.ts
@@ -1,8 +1,8 @@
 import { status } from "./status.ts";
-import * as path from "@std/path";
+import * as path from "jsr:@std/path@^1.0.8";
 import sdk, { getLatestVersion } from "../../sdk.ts";
 import { getProjectItemType } from "./paths.ts";
-import ValTown from "@valtown/sdk";
+import ValTown from "jsr:@valtown/sdk@^0.36.0";
 import { ProjectItem } from "../../consts.ts";
 
 /**

--- a/src/vt/git/push.ts
+++ b/src/vt/git/push.ts
@@ -1,9 +1,9 @@
-import { status } from "~/vt/git/status.ts";
+import { status } from "./status.ts";
 import * as path from "@std/path";
-import sdk, { getLatestVersion } from "~/sdk.ts";
-import { getProjectItemType } from "~/vt/git/paths.ts";
+import sdk, { getLatestVersion } from "../../sdk.ts";
+import { getProjectItemType } from "./paths.ts";
 import ValTown from "@valtown/sdk";
-import { ProjectItem } from "~/consts.ts";
+import { ProjectItem } from "../../consts.ts";
 
 /**
  * Pushes latest changes from a vt folder into a Val Town project.

--- a/src/vt/git/status.ts
+++ b/src/vt/git/status.ts
@@ -1,8 +1,8 @@
 import sdk from "../../sdk.ts";
-import type ValTown from "@valtown/sdk";
+import type ValTown from "jsr:@valtown/sdk@^0.36.0";
 import { shouldIgnore } from "./paths.ts";
-import * as fs from "@std/fs";
-import * as path from "@std/path";
+import * as fs from "jsr:@std/fs@^1.0.13";
+import * as path from "jsr:@std/path@^1.0.8";
 
 const STAT_PROMISES_BATCH_SIZE = 50;
 

--- a/src/vt/git/status.ts
+++ b/src/vt/git/status.ts
@@ -1,6 +1,6 @@
-import sdk from "~/sdk.ts";
+import sdk from "../../sdk.ts";
 import type ValTown from "@valtown/sdk";
-import { shouldIgnore } from "~/vt/git/paths.ts";
+import { shouldIgnore } from "./paths.ts";
 import * as fs from "@std/fs";
 import * as path from "@std/path";
 

--- a/src/vt/git/tests/cases.ts
+++ b/src/vt/git/tests/cases.ts
@@ -1,4 +1,4 @@
-import { ExpectedProjectInode } from "~/vt/git/tests/utils.ts";
+import { ExpectedProjectInode } from "./utils.ts";
 
 export interface TestCaseBranchData {
   version: number;

--- a/src/vt/git/tests/checkout_test.ts
+++ b/src/vt/git/tests/checkout_test.ts
@@ -1,11 +1,11 @@
-import { clone } from "~/vt/git/clone.ts";
-import { doWithTempDir } from "~/vt/git/utils.ts";
-import { assertEquals } from "@std/assert";
-import { verifyProjectStructure } from "~/vt/git/tests/utils.ts";
-import { checkout } from "~/vt/git/checkout.ts";
-import { testCases } from "~/vt/git/tests/cases.ts";
-import sdk, { branchNameToId } from "~/sdk.ts";
-import { DEFAULT_BRANCH_NAME } from "~/consts.ts";
+import { clone } from "../clone.ts";
+import { doWithTempDir } from "../utils.ts";
+import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { verifyProjectStructure } from "./utils.ts";
+import { checkout } from "../checkout.ts";
+import { testCases } from "./cases.ts";
+import sdk, { branchNameToId } from "../../../sdk.ts";
+import { DEFAULT_BRANCH_NAME } from "../../../consts.ts";
 
 // Run test for checking out branches that already exist
 for (const testCase of testCases) {

--- a/src/vt/git/tests/clone_test.ts
+++ b/src/vt/git/tests/clone_test.ts
@@ -1,8 +1,8 @@
-import { clone } from "~/vt/git/clone.ts";
-import { doWithTempDir } from "~/vt/git/utils.ts";
-import { assertEquals } from "@std/assert";
-import { verifyProjectStructure } from "~/vt/git/tests/utils.ts";
-import { testCases } from "~/vt/git/tests/cases.ts";
+import { clone } from "../clone.ts";
+import { doWithTempDir } from "../utils.ts";
+import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { verifyProjectStructure } from "./utils.ts";
+import { testCases } from "./cases.ts";
 
 for (const testCase of testCases) {
   for (const branchId in testCase.branches) {

--- a/src/vt/git/tests/pull_test.ts
+++ b/src/vt/git/tests/pull_test.ts
@@ -1,9 +1,9 @@
-import { clone } from "~/vt/git/clone.ts";
-import { doWithTempDir } from "~/vt/git/utils.ts";
-import { assertEquals } from "@std/assert";
-import { pull } from "~/vt/git/pull.ts";
-import { verifyProjectStructure } from "~/vt/git/tests/utils.ts";
-import { testCases } from "~/vt/git/tests/cases.ts";
+import { clone } from "../clone.ts";
+import { doWithTempDir } from "../utils.ts";
+import { assertEquals } from "jsr:@std/assert@^1.0.0";
+import { pull } from "../pull.ts";
+import { verifyProjectStructure } from "../tests/utils.ts";
+import { testCases } from "../tests/cases.ts";
 
 for (const testCase of testCases) {
   for (const branchId in testCase.branches) {

--- a/src/vt/git/tests/push_test.ts
+++ b/src/vt/git/tests/push_test.ts
@@ -1,10 +1,10 @@
-import { doWithTempDir } from "~/vt/git/utils.ts";
-import { doWithNewProject } from "~/vt/git/tests/utils.ts";
-import sdk from "~/sdk.ts";
-import { push } from "~/vt/git/push.ts";
-import { assertEquals, assertRejects } from "@std/assert";
-import { join } from "@std/path";
-import ValTown from "@valtown/sdk";
+import { doWithTempDir } from "../utils.ts";
+import { doWithNewProject } from "./utils.ts";
+import sdk from "../../../sdk.ts";
+import { push } from "../push.ts";
+import { assertEquals, assertRejects } from "jsr:@std/assert@^1.0.0";
+import { join } from "jsr:@std/path@^1.0.8";
+import ValTown from "jsr:@valtown/sdk@^0.36.0";
 
 Deno.test({
   name: "test pushing",

--- a/src/vt/git/tests/status_test.ts
+++ b/src/vt/git/tests/status_test.ts
@@ -1,9 +1,9 @@
-import { FileStatus, status, StatusResult } from "~/vt/git/status.ts";
-import * as path from "@std/path";
-import { doWithTempDir } from "~/vt/git/utils.ts";
-import { clone } from "~/vt/git/clone.ts";
-import { assert } from "@std/assert";
-import { TestCaseBranchData, testCases } from "~/vt/git/tests/cases.ts";
+import { FileStatus, status, StatusResult } from "../status.ts";
+import * as path from "jsr:@std/path@^1.0.8";
+import { doWithTempDir } from "../utils.ts";
+import { clone } from "../clone.ts";
+import { assert } from "jsr:@std/assert@^1.0.0";
+import { TestCaseBranchData, testCases } from "./cases.ts";
 
 for (const testCase of testCases) {
   for (const branchId in testCase.branches) {

--- a/src/vt/git/tests/utils.ts
+++ b/src/vt/git/tests/utils.ts
@@ -1,6 +1,6 @@
-import { join } from "@std/path";
-import { walk } from "@std/fs";
-import sdk, { branchNameToId } from "~/sdk.ts";
+import { join } from "jsr:@std/path@^1.0.8";
+import { walk } from "jsr:@std/fs@^1.0.13";
+import sdk, { branchNameToId } from "../../../sdk.ts";
 
 export interface ExpectedProjectInode {
   path: string;

--- a/src/vt/git/utils.ts
+++ b/src/vt/git/utils.ts
@@ -1,9 +1,9 @@
 import { StatusResult } from "./status.ts";
-import * as path from "@std/path";
+import * as path from "jsr:@std/path@^1.0.8";
 import { shouldIgnore } from "./paths.ts";
-import ValTown from "@valtown/sdk";
+import ValTown from "jsr:@valtown/sdk@^0.36.0";
 import sdk from "../../sdk.ts";
-import { copy, ensureDir } from "@std/fs";
+import { copy, ensureDir } from "jsr:@std/fs@^1.0.13";
 
 /**
  * Creates a temporary directory and returns it with a cleanup function.

--- a/src/vt/git/utils.ts
+++ b/src/vt/git/utils.ts
@@ -1,8 +1,8 @@
-import { StatusResult } from "~/vt/git/status.ts";
+import { StatusResult } from "./status.ts";
 import * as path from "@std/path";
-import { shouldIgnore } from "~/vt/git/paths.ts";
+import { shouldIgnore } from "./paths.ts";
 import ValTown from "@valtown/sdk";
-import sdk from "~/sdk.ts";
+import sdk from "../../sdk.ts";
 import { copy, ensureDir } from "@std/fs";
 
 /**

--- a/src/vt/vt/VTClient.ts
+++ b/src/vt/vt/VTClient.ts
@@ -5,10 +5,10 @@ import VTMeta from "./VTMeta.ts";
 import { pull } from "../git/pull.ts";
 import { push } from "../git/push.ts";
 import { status, StatusResult } from "../git/status.ts";
-import { debounce } from "jsr:@std/async/debounce";
+import { debounce } from "jsr:@std/async@^1.0.11/debounce";
 import { checkout } from "../git/checkout.ts";
 import { isDirty } from "../git/utils.ts";
-import ValTown from "@valtown/sdk";
+import ValTown from "jsr:@valtown/sdk@^0.36.0";
 
 /**
  * The VTClient class is an abstraction on a VT directory that exposes

--- a/src/vt/vt/VTClient.ts
+++ b/src/vt/vt/VTClient.ts
@@ -1,13 +1,13 @@
-import { clone } from "~/vt/git/clone.ts";
-import { DEFAULT_BRANCH_NAME, DEFAULT_IGNORE_PATTERNS } from "~/consts.ts";
-import sdk, { branchNameToId, getLatestVersion } from "~/sdk.ts";
-import VTMeta from "~/vt/vt/VTMeta.ts";
-import { pull } from "~/vt/git/pull.ts";
-import { push } from "~/vt/git/push.ts";
-import { status, StatusResult } from "~/vt/git/status.ts";
+import { clone } from "../git/clone.ts";
+import { DEFAULT_BRANCH_NAME, DEFAULT_IGNORE_PATTERNS } from "../../consts.ts";
+import sdk, { branchNameToId, getLatestVersion } from "../../sdk.ts";
+import VTMeta from "./VTMeta.ts";
+import { pull } from "../git/pull.ts";
+import { push } from "../git/push.ts";
+import { status, StatusResult } from "../git/status.ts";
 import { debounce } from "jsr:@std/async/debounce";
-import { checkout } from "~/vt/git/checkout.ts";
-import { isDirty } from "~/vt/git/utils.ts";
+import { checkout } from "../git/checkout.ts";
+import { isDirty } from "../git/utils.ts";
 import ValTown from "@valtown/sdk";
 
 /**

--- a/src/vt/vt/VTMeta.ts
+++ b/src/vt/vt/VTMeta.ts
@@ -1,11 +1,11 @@
-import z from "zod";
+import { z } from "npm:zod@^3.24.2";
 import { VTMetaConfigJsonSchema } from "./schemas.ts";
 import {
   CONFIG_FILE_NAME,
   META_FOLDER_NAME,
   META_LOCK_FILE_NAME,
 } from "../../consts.ts";
-import * as path from "@std/path";
+import * as path from "jsr:@std/path@^1.0.8";
 
 /**
  * The VTMeta class manages .vt/* configuration files and provides abstractions

--- a/src/vt/vt/VTMeta.ts
+++ b/src/vt/vt/VTMeta.ts
@@ -1,10 +1,10 @@
 import z from "zod";
-import { VTMetaConfigJsonSchema } from "~/vt/vt/schemas.ts";
+import { VTMetaConfigJsonSchema } from "./schemas.ts";
 import {
   CONFIG_FILE_NAME,
   META_FOLDER_NAME,
   META_LOCK_FILE_NAME,
-} from "~/consts.ts";
+} from "../../consts.ts";
 import * as path from "@std/path";
 
 /**

--- a/src/vt/vt/schemas.ts
+++ b/src/vt/vt/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "npm:zod@^3.24.2";
 
 /**
  * JSON schema for the VTMetaConfig JSON file.

--- a/vt.ts
+++ b/vt.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env -S deno run -A
-import { cmd as vt } from "~/cmd/root.ts";
+import { cmd as vt } from "./src/cmd/root.ts";
 
 export default vt;
 


### PR DESCRIPTION
Ok, this is a sad one.

In order to make this project val-town compliant we have to get rid of the imports in deno.json.

Now it can be installed with: 
```
deno install --global -A --name=vt https://raw.githubusercontent.com/val-town/vt/refs/heads/make-http-importable/vt.ts
```

See: https://github.com/denoland/deno/issues/25994 for some related discussion.

Certainly not the best, but a real platform constraint at the moment given that we are so reliant on http imports. So hopefully at least a good thing for us to be experiencing this directly.