### PR TITLE
Allow override of install cache dir

### DIFF
--- a/install.ts
+++ b/install.ts
@@ -40,7 +40,7 @@ const process = new Deno.Command(Deno.execPath(), {
     "run",
     "--allow-read",
     "--allow-write",
-    "--allow-sys=osRelease",
+    "--allow-sys",
     "--allow-env=VAL_TOWN_API_KEY,VAL_TOWN_BASE_URL",
     "--allow-net",
     "--allow-run",

--- a/install.ts
+++ b/install.ts
@@ -40,6 +40,7 @@ const process = new Deno.Command(Deno.execPath(), {
     "run",
     "--allow-read",
     "--allow-write",
+    "--allow-sys=osRelease",
     "--allow-env=VAL_TOWN_API_KEY,VAL_TOWN_BASE_URL",
     "--allow-net",
     "--allow-run",

--- a/install.ts
+++ b/install.ts
@@ -8,7 +8,7 @@ import { join } from "jsr:@std/path@^1.0.8";
 const installVersion = "0.0.1-alpha.1";
 
 const appName = "vt";
-const cacheDir = join(xdg.cache(), appName);
+const cacheDir = Deno.env.get("VT_CACHE_DIR") || join(xdg.cache(), appName);
 await ensureDir(cacheDir);
 const vtDenoJsonPath = join(cacheDir, `${installVersion}_deno.json`);
 


### PR DESCRIPTION
I am not entirely sure of the merit here, but I need this for something I'm working on so that I can have more control over the script install location. Overriding XDG_CACHE_HOME wasn't working because then deno would also move DENO_DIR into that cache. 