### PR TITLE
Remove debug print

### DIFF
--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -57,7 +57,6 @@ export async function doWithSpinner(
 
     return await callback(spinner);
   } catch (e) {
-    console.log(e);
     // Use the provided or default error cleaning function
     const cleanedErrorMessage = cleanError(e);
 


### PR DESCRIPTION
Forgot to remove a console.log(e) in the doWithSpinner, so now all error traces are printed. Just a very quick fix!