### PR TITLE
Sort the file list output

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/src/cmd/lib/utils.ts
+++ b/src/cmd/lib/utils.ts
@@ -118,6 +118,8 @@ export function displayFileStateChanges(
     includeTypes = true,
   } = options;
   const totalChanges = fileStateChanges.changes();
+  const fileStateChangesEntriesSorted = fileStateChanges
+    .entries({ sorted: true });
 
   // Exit early if we do not show empty
   if (totalChanges === 0 && !showEmpty) return;
@@ -126,13 +128,13 @@ export function displayFileStateChanges(
   if (headerText && totalChanges !== 0) console.log(headerText);
 
   // Calculate the longest type length from all files
-  const maxTypeLength = fileStateChanges.entries()
+  const maxTypeLength = fileStateChangesEntriesSorted
     .filter(([type]) => type !== "not_modified")
     .flatMap(([_, files]) => files)
     .reduce((max, file) => Math.max(max, file.type.length), 0);
 
   // Print all changed files state
-  for (const [type, files] of fileStateChanges.entries()) {
+  for (const [type, files] of fileStateChangesEntriesSorted) {
     if (type !== "not_modified") {
       for (const file of files) {
         console.log(
@@ -156,7 +158,7 @@ export function displayFileStateChanges(
       }
     } else {
       console.log("\n" + summaryPrefix);
-      for (const [type, files] of fileStateChanges.entries()) {
+      for (const [type, files] of fileStateChangesEntriesSorted) {
         if (type !== "not_modified" && files.length > 0) {
           const typeColor = STATUS_STYLES[type as keyof FileState];
           const coloredType = typeColor.color(type);

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -62,3 +62,12 @@ export type ProjectItemType = typeof ProjectItems[number];
 export type ProjectFileType = Exclude<ProjectItemType, "directory">;
 
 export const RECENT_VERSION_COUNT = 5;
+
+export const TYPE_PRIORITY: Record<ProjectItemType, number> = {
+  "script": 0,
+  "email": 1,
+  "http": 2,
+  "directory": 3,
+  "file": 4,
+  "interval": 5,
+};

--- a/src/vt/lib/FileState.ts
+++ b/src/vt/lib/FileState.ts
@@ -85,6 +85,7 @@ export class FileState {
    * 1. Path segment count (longest paths first)
    * 2. Type (created, deleted, modified, etc.)
    * 3. Basename length
+   * 4. Alphabetical order of the type if all else is equal
    *
    * @param options - Optional configuration {sorted: boolean}
    * @returns An array of entries from the JSON representation
@@ -123,6 +124,11 @@ export class FileState {
       const basenameB = segmentsB.length > 0
         ? segmentsB[segmentsB.length - 1]
         : "";
+
+      if (basenameA === basenameB) {
+        // 4. If basenames are equal, compare alphabetically by type
+        return typeA.localeCompare(typeB);
+      }
 
       return basenameA.length - basenameB.length;
     });

--- a/src/vt/lib/FileState.ts
+++ b/src/vt/lib/FileState.ts
@@ -1,3 +1,4 @@
+import { basename } from "@std/path";
 import type { ProjectItemType } from "~/consts.ts";
 
 export interface FileInfo {
@@ -118,12 +119,8 @@ export class FileState {
       }
 
       // 3. If types are equal, compare by basename length
-      const basenameA = segmentsA.length > 0
-        ? segmentsA[segmentsA.length - 1]
-        : "";
-      const basenameB = segmentsB.length > 0
-        ? segmentsB[segmentsB.length - 1]
-        : "";
+      const basenameA = basename(pathA);
+      const basenameB = basename(pathB);
 
       if (basenameA === basenameB) {
         // 4. If basenames are equal, compare alphabetically by type


### PR DESCRIPTION
Sort output by:
1) path segment count (one/two/three)
2) val type (or file or dir)
3) basename string length
4) alphabetical

![805a4e1e-0466-441c-97e6-7f308fc3dc50](https://github.com/user-attachments/assets/792d9e05-4610-4c18-98eb-5d042ea86db4)
