### PR TITLE
Fix checkout preserving changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ platform.
 
 ```
 Usage:   vt
-Version: 0.0.10
+Version: 0.0.11
 
 Options:
 
@@ -54,7 +54,7 @@ Run `vt` to confirm everything is working:
 ```bash
 $ vt --version
 
-vt 0.0.7
+vt 0.0.11
 ```
 
 ## Getting Started

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/src/cmd/lib/watch.ts
+++ b/src/cmd/lib/watch.ts
@@ -47,8 +47,8 @@ export const watchCmd = new Command()
     "Debounce delay in milliseconds",
     { default: 1500 },
   )
-  .action((options) => {
-    doWithSpinner("Starting watch...", async (spinner) => {
+  .action(async (options) => {
+    await doWithSpinner("Starting watch...", async (spinner) => {
       const vt = VTClient.from(await findVtRoot(Deno.cwd()));
 
       // Get initial branch information for display

--- a/src/cmd/tests/watch_test.ts
+++ b/src/cmd/tests/watch_test.ts
@@ -124,4 +124,5 @@ Deno.test({
       });
     });
   },
+  sanitizeResources: false,
 });

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -57,7 +57,7 @@ export async function doWithSpinner(
 
     return await callback(spinner);
   } catch (e) {
-    console.log(e)
+    console.log(e);
     // Use the provided or default error cleaning function
     const cleanedErrorMessage = cleanError(e);
 

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -57,7 +57,6 @@ export async function doWithSpinner(
 
     return await callback(spinner);
   } catch (e) {
-    console.log(e);
     // Use the provided or default error cleaning function
     const cleanedErrorMessage = cleanError(e);
 

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -57,6 +57,7 @@ export async function doWithSpinner(
 
     return await callback(spinner);
   } catch (e) {
+    console.log(e)
     // Use the provided or default error cleaning function
     const cleanedErrorMessage = cleanError(e);
 


### PR DESCRIPTION
Fix an issue with checking out between branches not preserving untracked files. Extension of the previous checkout logic fixes that covers a missed edge case.