### PR TITLE
Project Modifications are not Dirty During Checkout

### DIFF
--- a/src/cmd/lib/checkout.ts
+++ b/src/cmd/lib/checkout.ts
@@ -240,7 +240,7 @@ export const checkoutCmd = new Command()
 
               // Report the success, which is either a successful switch or a
               // successful fork
-              tty.scrollDown(1);
+              tty.scrollDown(2);
               spinner.succeed(
                 isNewBranch
                   ? `Created and switched to new branch "${targetBranch}" from "${checkoutResult.fromBranch.name}"`

--- a/src/cmd/lib/checkout.ts
+++ b/src/cmd/lib/checkout.ts
@@ -234,13 +234,12 @@ export const checkoutCmd = new Command()
                   includeSummary: true,
                 }),
               );
-              console.log();
               // If no changes nothing was printed, so we don't need to log state info
               if (checkoutResult.fileStateChanges.changes() > 0) console.log();
 
               // Report the success, which is either a successful switch or a
               // successful fork
-              tty.scrollDown(2);
+              tty.scrollDown(1);
               spinner.succeed(
                 isNewBranch
                   ? `Created and switched to new branch "${targetBranch}" from "${checkoutResult.fromBranch.name}"`

--- a/src/cmd/lib/checkout.ts
+++ b/src/cmd/lib/checkout.ts
@@ -10,6 +10,7 @@ import { findVtRoot } from "~/vt/vt/utils.ts";
 import { colors } from "@cliffy/ansi/colors";
 import { Confirm } from "@cliffy/prompt";
 import { tty } from "@cliffy/ansi/tty";
+import sdk from "~/sdk.ts";
 
 const toListBranchesCmd = "Use `vt branch` to list branches.";
 const noChangesToStateMsg = "No changes were made to local state";
@@ -67,6 +68,12 @@ export const checkoutCmd = new Command()
           const vt = VTClient.from(await findVtRoot(Deno.cwd()));
           const config = await vt.getMeta().loadConfig();
 
+          // Get the current branch data
+          const currentBranchData = await sdk.projects.branches.retrieve(
+            config.projectId,
+            config.currentBranch,
+          );
+
           // Validate input parameters
           if (!branch && !existingBranchName) {
             throw new Error(
@@ -89,10 +96,7 @@ export const checkoutCmd = new Command()
               },
             );
 
-            if (
-              dryCheckoutResult.toBranch &&
-              config.currentBranch === dryCheckoutResult.toBranch.id
-            ) {
+            if (currentBranchData.name === existingBranchName) {
               spinner.warn(
                 `You are already on branch "${dryCheckoutResult.fromBranch.name}"`,
               );

--- a/src/cmd/lib/checkout.ts
+++ b/src/cmd/lib/checkout.ts
@@ -165,8 +165,8 @@ export const checkoutCmd = new Command()
                   },
                 );
 
-                console.log();
                 console.log(dangerousChanges);
+                console.log();
 
                 // Ask for confirmation to proceed despite dirty state
                 const shouldProceed = await Confirm.prompt({
@@ -181,7 +181,7 @@ export const checkoutCmd = new Command()
                 if (!shouldProceed) Deno.exit(0);
                 else {
                   prepareForResult = () =>
-                    tty.eraseLines(dangerousChanges.split("\n").length + 2);
+                    tty.eraseLines(dangerousChanges.split("\n").length + 3);
                 }
               }
             }
@@ -234,6 +234,7 @@ export const checkoutCmd = new Command()
                   includeSummary: true,
                 }),
               );
+              console.log();
               // If no changes nothing was printed, so we don't need to log state info
               if (checkoutResult.fileStateChanges.changes() > 0) console.log();
 

--- a/src/cmd/lib/pull.ts
+++ b/src/cmd/lib/pull.ts
@@ -2,11 +2,13 @@ import { Command } from "@cliffy/command";
 import { doWithSpinner } from "~/cmd/utils.ts";
 import VTClient from "~/vt/vt/VTClient.ts";
 import { findVtRoot } from "~/vt/vt/utils.ts";
+import { tty } from "@cliffy/ansi/tty";
 import {
   displayFileStateChanges,
   noChangesDryRunMsg,
 } from "~/cmd/lib/utils.ts";
 import { Confirm } from "@cliffy/prompt";
+import { colors } from "@cliffy/ansi/colors";
 
 export const pullCmd = new Command()
   .name("pull")
@@ -28,18 +30,20 @@ export const pullCmd = new Command()
         // Check if dirty, then early exit if it's dirty and they don't
         // want to proceed. If in force mode don't do this check.
         const fileStateChanges = await vt.pull({ dryRun: true });
+        let prepareForResult = () => {};
         if ((await vt.isDirty()) && !force) {
           spinner.stop();
 
-          // Display what would be pulled when dirty
-          displayFileStateChanges(fileStateChanges, {
-            headerText: "Changes that would be pulled:",
+          const dangerousChanges = displayFileStateChanges(fileStateChanges, {
+            headerText: `Changes that ${colors.underline("would be pulled")}:`,
             summaryText: "Would pull:",
             emptyMessage: "No changes to pull, local state is up to date",
             includeTypes: !dryRun,
             includeSummary: true,
-          });
-          console.log();
+          }) + "\n";
+
+          // Display what would be pulled when dirty
+          console.log(dangerousChanges);
 
           // No need to confirm since they are just doing a dry run
           if (dryRun) return;
@@ -51,32 +55,39 @@ export const pullCmd = new Command()
               " Are you sure you want to proceed?",
             default: false,
           });
-          if (!shouldProceed) Deno.exit(0); // This is what they wanted
-          console.log();
+          if (!shouldProceed) {
+            Deno.exit(0);
+          } else {
+            prepareForResult = () =>
+              tty
+                .eraseLines(dangerousChanges.split("\n").length + 2);
+          }
         }
 
         if (dryRun) {
           spinner.stop();
-          displayFileStateChanges(fileStateChanges, {
-            headerText: "Changes that would be pulled:",
+          prepareForResult();
+          console.log(displayFileStateChanges(fileStateChanges, {
+            headerText: `Changes that ${colors.underline("would be pulled")}:`,
             summaryText: "Would pull:",
             emptyMessage: "No changes to pull, local state is up to date",
             includeTypes: !dryRun,
             includeSummary: true,
-          });
+          }));
           console.log();
           spinner.succeed(noChangesDryRunMsg);
         } else {
           // Perform the actual pull
           const realPullChanges = await vt.pull();
           spinner.stop();
-          displayFileStateChanges(realPullChanges, {
-            headerText: "Changes pulled:",
+          prepareForResult();
+          console.log(displayFileStateChanges(realPullChanges, {
+            headerText: "Changes " + colors.underline("pulled:"),
             summaryText: "Pulled:",
             emptyMessage: "No changes were pulled, local state is up to date",
             includeTypes: !dryRun,
             includeSummary: true,
-          });
+          }));
           console.log();
           spinner.succeed("Successfully pulled the latest changes");
         }

--- a/src/cmd/lib/push.ts
+++ b/src/cmd/lib/push.ts
@@ -33,12 +33,12 @@ export const pushCmd = new Command()
           const statusResult = await vt.push({ dryRun: true });
           spinner.stop();
 
-          displayFileStateChanges(statusResult, {
+          console.log(displayFileStateChanges(statusResult, {
             headerText: "Changes that would be pushed:",
             summaryText: "Would push:",
             emptyMessage: nothingNewToPushMsg,
             includeSummary: true,
-          });
+          }));
 
           console.log();
           spinner.succeed(noChangesDryRunMsg);
@@ -48,11 +48,11 @@ export const pushCmd = new Command()
           spinner.stop();
 
           // Display the changes that were pushed
-          displayFileStateChanges(statusResult, {
+          console.log(displayFileStateChanges(statusResult, {
             headerText: "Pushed:",
             emptyMessage: nothingNewToPushMsg,
             includeSummary: true,
-          });
+          }));
 
           console.log();
           spinner.succeed("Successfully pushed local changes");

--- a/src/cmd/lib/status.ts
+++ b/src/cmd/lib/status.ts
@@ -40,10 +40,10 @@ export const statusCmd = new Command()
       );
       console.log();
 
-      displayFileStateChanges(await vt.status(), {
+      console.log(displayFileStateChanges(await vt.status(), {
         headerText: "Local Changes:",
         emptyMessage: "No changes locally to push.",
         summaryText: "Changes to be pushed:",
-      });
+      }));
     });
   });

--- a/src/cmd/lib/utils.ts
+++ b/src/cmd/lib/utils.ts
@@ -101,7 +101,7 @@ export function displayFileStateChanges(
     includeSummary?: boolean;
     includeTypes?: boolean;
   },
-): void {
+): string {
   const {
     headerText: headerText,
     summaryText: summaryPrefix = "Summary:",
@@ -110,13 +110,14 @@ export function displayFileStateChanges(
     includeSummary = true,
     includeTypes = true,
   } = options;
+  const output: string[] = [];
   const totalChanges = fileStateChanges.changes();
 
   // Exit early if we do not show empty
-  if (totalChanges === 0 && !showEmpty) return;
+  if (totalChanges === 0 && !showEmpty) return "";
 
   // Display header if provided
-  if (headerText && totalChanges !== 0) console.log(headerText);
+  if (headerText && totalChanges !== 0) output.push(headerText);
 
   // Calculate the longest type length from all files
   const maxTypeLength = fileStateChanges.entries()
@@ -128,7 +129,7 @@ export function displayFileStateChanges(
   for (const [type, files] of fileStateChanges.entries()) {
     if (type !== "not_modified") {
       for (const file of files) {
-        console.log(
+        output.push(
           "  " +
             formatStatus(
               file.path,
@@ -145,19 +146,21 @@ export function displayFileStateChanges(
   if (includeSummary) {
     if (totalChanges === 0) {
       if (emptyMessage) {
-        console.log(colors.green(emptyMessage));
+        output.push(colors.green(emptyMessage));
       }
     } else {
-      console.log("\n" + summaryPrefix);
+      output.push("\n" + summaryPrefix);
       for (const [type, files] of fileStateChanges.entries()) {
         if (type !== "not_modified" && files.length > 0) {
           const typeColor = STATUS_STYLES[type as keyof FileState];
           const coloredType = typeColor.color(type);
-          console.log("  " + files.length + " " + coloredType);
+          output.push("  " + files.length + " " + coloredType);
         }
       }
     }
   }
+
+  return output.join("\n");
 }
 
 export const noChangesDryRunMsg = "Dry run completed. " +

--- a/src/cmd/lib/watch.ts
+++ b/src/cmd/lib/watch.ts
@@ -88,11 +88,11 @@ export const watchCmd = new Command()
           try {
             if (fileStateChanges.size() > 0) {
               console.log();
-              displayFileStateChanges(fileStateChanges, {
+              console.log(displayFileStateChanges(fileStateChanges, {
                 emptyMessage: "No changes detected. Continuing to watch...",
                 headerText: "New changes detected",
                 summaryText: "Pushed:",
-              });
+              }));
               console.log();
               console.log(watchingForChangesLine());
             }

--- a/src/cmd/tests/checkout_test.ts
+++ b/src/cmd/tests/checkout_test.ts
@@ -6,6 +6,87 @@ import type { ProjectFileType } from "~/consts.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";
 import { assert, assertStringIncludes } from "@std/assert";
 import { exists } from "@std/fs";
+import { deadline } from "@std/async";
+
+Deno.test({
+  name: "checkout with remote modifications on current branch is allowed",
+  async fn() {
+    await doWithTempDir(async (tmpDir) => {
+      await doWithNewProject(async ({ project, branch: mainBranch }) => {
+        // Create initial file on main branch
+        await sdk.projects.files.create(
+          project.id,
+          {
+            path: "main-file.js",
+            content: "console.log('Initial content');",
+            branch_id: mainBranch.id,
+            type: "file" as ProjectFileType,
+          },
+        );
+
+        // Create a feature branch
+        const featureBranch = await sdk.projects.branches.create(
+          project.id,
+          { name: "feature-branch", branchId: mainBranch.id },
+        );
+
+        // Add a file to feature branch
+        await sdk.projects.files.create(
+          project.id,
+          {
+            path: "feature-file.js",
+            content: "console.log('Feature branch file');",
+            branch_id: featureBranch.id,
+            type: "file" as ProjectFileType,
+          },
+        );
+
+        // Clone the project (defaults to main branch)
+        await runVtCommand(["clone", project.name], tmpDir);
+        const fullPath = join(tmpDir, project.name);
+
+        // Make a remote change to main branch after cloning
+        await sdk.projects.files.update(
+          project.id,
+          {
+            branch_id: mainBranch.id,
+            path: "main-file.js",
+            content: "console.log('Remote modification');",
+          },
+        );
+
+        // Now try checking out to feature branch
+        // This should succeed without requiring force flag or showing dirty warning
+        const [checkoutOutput] = await runVtCommand([
+          "checkout",
+          "feature-branch",
+        ], fullPath);
+
+        // Should successfully switch branches without warning about dirty state
+        assertStringIncludes(
+          checkoutOutput,
+          'Switched to branch "feature-branch"',
+        );
+
+        // Should not contain warnings about dirty working directory
+        assert(
+          !checkoutOutput.includes("proceed with checkout anyway"),
+          "Checkout should not warn about dirty working directory with remote changes",
+        );
+
+        // Verify we're on feature branch by checking for feature file
+        assert(
+          await exists(join(fullPath, "feature-file.js")),
+          "feature-file.js should exist after checkout",
+        );
+
+        // Check status to confirm we're on feature branch
+        const [statusOutput] = await runVtCommand(["status"], fullPath);
+        assertStringIncludes(statusOutput, "On branch feature-branch@");
+      });
+    });
+  },
+});
 
 Deno.test({
   name: "checkout -b preserves local unpushed changes",
@@ -243,80 +324,105 @@ Deno.test({
 
 Deno.test({
   name: "warning on modified files",
-  async fn() {
-    await doWithTempDir(async (tmpDir) => {
-      await doWithNewProject(async ({ project, branch }) => {
-        // Create initial file on main branch
-        await sdk.projects.files.create(
-          project.id,
-          {
-            path: "shared-file.js",
-            content: "console.log('Original content');",
-            branch_id: branch.id,
-            type: "file" as ProjectFileType,
-          },
-        );
+  async fn(t) {
+    // Put an 8s deadline, since in the past we had an issue with this stalling
+    // due to waiting for a user interaction
+    await deadline(
+      (async () => {
+        return await doWithTempDir(async (tmpDir) => {
+          await doWithNewProject(async ({ project, branch }) => {
+            let fullPath: string;
 
-        // Create a feature branch
-        const featureBranch = await sdk.projects.branches.create(
-          project.id,
-          { name: "feature", branchId: branch.id },
-        );
+            await t.step("create initial file on main branch", async () => {
+              await sdk.projects.files.create(
+                project.id,
+                {
+                  path: "shared-file.js",
+                  content: "console.log('Original content');",
+                  branch_id: branch.id,
+                  type: "file" as ProjectFileType,
+                },
+              );
+            });
 
-        // Modify the file on feature branch
-        await sdk.projects.files.update(
-          project.id,
-          {
-            branch_id: featureBranch.id,
-            path: "shared-file.js",
-            content: "console.log('Feature branch content');",
-          },
-        );
+            await t.step(
+              "create and modify file on feature branch",
+              async () => {
+                // Create a feature branch
+                const featureBranch = await sdk.projects.branches.create(
+                  project.id,
+                  { name: "feature", branchId: branch.id },
+                );
 
-        // Clone the project (defaults to main branch)
-        await runVtCommand(["clone", project.name], tmpDir);
-        const fullPath = join(tmpDir, project.name);
+                // Modify the file on feature branch
+                await sdk.projects.files.update(
+                  project.id,
+                  {
+                    branch_id: featureBranch.id,
+                    path: "shared-file.js",
+                    content: "console.log('Feature branch content');",
+                  },
+                );
+              },
+            );
 
-        // Modify the shared file locally while on main branch
-        await Deno.writeTextFile(
-          join(fullPath, "shared-file.js"),
-          "console.log('Modified locally on main');",
-        );
+            await t.step("clone project and modify file locally", async () => {
+              // Clone the project (defaults to main branch)
+              await runVtCommand(["clone", project.name], tmpDir);
+              fullPath = join(tmpDir, project.name);
 
-        // Try checking out to feature branch - should see warning about local changes
-        const [checkoutOutput] = await runVtCommand([
-          "checkout",
-          "feature",
-        ], fullPath);
+              // Modify the shared file locally while on main branch
+              await Deno.writeTextFile(
+                join(fullPath, "shared-file.js"),
+                "console.log('Modified locally on main');",
+              );
+            });
 
-        // Should see warning about dangerous changes
-        assertStringIncludes(
-          checkoutOutput,
-          "proceed with checkout anyway",
-        );
-        assertStringIncludes(checkoutOutput, "Changed:"); // runVtCommand spams yes
-        assertStringIncludes(checkoutOutput, "shared-file.js");
+            await t.step(
+              "checkout with warning about local changes",
+              async () => {
+                // Try checking out to feature branch - should see warning about local changes
+                const [checkoutOutput] = await runVtCommand(
+                  ["checkout", "feature"],
+                  fullPath,
+                );
 
-        // Try with force option
-        const [forceCheckoutOutput] = await runVtCommand([
-          "checkout",
-          "feature",
-          "-f",
-        ], fullPath);
-        assertStringIncludes(
-          forceCheckoutOutput,
-          'Switched to branch "feature"',
-        );
+                // Should see warning about dangerous changes
+                assertStringIncludes(
+                  checkoutOutput,
+                  "proceed with checkout anyway",
+                );
+                assertStringIncludes(checkoutOutput, "Changed:"); // runVtCommand spams yes
+                assertStringIncludes(checkoutOutput, "shared-file.js");
+              },
+            );
 
-        // The content should now be the feature branch content
-        const fileContent = await Deno.readTextFile(
-          join(fullPath, "shared-file.js"),
-        );
-        assert(
-          fileContent === "console.log('Feature branch content');",
-          "File content should match feature branch version after force checkout",
-        );
-      });
-    });
+            await t.step("force checkout overrides local changes", async () => {
+              // Try with force option
+              const [forceCheckoutOutput] = await runVtCommand([
+                "checkout",
+                "feature",
+                "-f",
+              ], fullPath);
+              assertStringIncludes(
+                forceCheckoutOutput,
+                'Switched to branch "feature"',
+              );
+
+              // The content should now be the feature branch content
+              const fileContent = await Deno.readTextFile(
+                join(fullPath, "shared-file.js"),
+              );
+              assert(
+                fileContent === "console.log('Feature branch content');",
+                "File content should match feature branch version after force checkout",
+              );
+            });
+          });
+        });
+      })(),
+      1000 * 8,
+    );
   },
+  sanitizeResources: false,
 });

--- a/src/vt/lib/FileState.ts
+++ b/src/vt/lib/FileState.ts
@@ -13,6 +13,7 @@ export type FileStatusType =
 export interface FileStatus extends FileInfo {
   status: FileStatusType;
   path: string;
+  where?: "local" | "remote";
 }
 
 /**
@@ -224,6 +225,36 @@ export class FileState {
 
     for (const file of this.not_modified) {
       if (predicate(file)) result.insert(file);
+    }
+
+    return result;
+  }
+
+  /**
+   * Creates a new FileState with entries transformed by the given mapping function.
+   *
+   * @param mapper - Function that transforms each entry. Takes a FileStatus and returns a new FileStatus.
+   * @returns A new FileState containing the transformed entries
+   */
+  public map(
+    mapper: (entry: FileStatus) => FileStatus,
+  ): FileState {
+    const result = new FileState();
+
+    for (const file of this.created) {
+      result.insert(mapper(file));
+    }
+
+    for (const file of this.deleted) {
+      result.insert(mapper(file));
+    }
+
+    for (const file of this.modified) {
+      result.insert(mapper(file));
+    }
+
+    for (const file of this.not_modified) {
+      result.insert(mapper(file));
     }
 
     return result;


### PR DESCRIPTION
This is another checkout edge case:

If you checkout from `branchA` to `branchB`, during the checkout, when looking at `foo.tsx`:
- If local mtime == remote mtime, it definitely wasn't modified (and we trust this right now. yes, theoretically the user could change the mtime to the exact millisecond of the project edit time without changing the file, and we would get a false positive, and people could lose their work)
- If local content is different from remote content:
- Previously, we would return that it is dirty. Now, I also check to see if the website modification is newer. If the modification locally is more recent, they could have local work that they didn't push, so we consider this dirty. BUT, if the remote modification is more recent, the only way this is possible is if they modified their utime locally. So we can safely assume this is NOT dirty.

I added a `where?: "local" | "remote"` which is only used for this purpose because when I add support for renames I'm going to have different status interfaces for the different status types, so the types will get better.

I also added Cliffy tty to overwrite the output message upon confirmation:

![recording](https://github.com/user-attachments/assets/b0211414-1fa5-4b7c-8612-b9459a2cb8f8)
