### PR TITLE
Add More to .vtignore

### DIFF
--- a/src/cmd/tests/clone_test.ts
+++ b/src/cmd/tests/clone_test.ts
@@ -8,6 +8,78 @@ import { doWithTempDir } from "~/vt/lib/utils.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";
 
 Deno.test({
+  name: "clone preserves custom deno.json and .vtignore",
+  permissions: {
+    read: true,
+    write: true,
+    net: true,
+    env: true,
+    run: true,
+  },
+  async fn(t) {
+    await doWithTempDir(async (tmpDir) => {
+      await doWithNewProject(async ({ project, branch }) => {
+        const customDenoJson = '{"tasks":{"custom":"echo test"}}';
+        const customVtignore = "custom_ignore_pattern";
+
+        await t.step("set up custom config files", async () => {
+          // Create custom deno.json
+          await sdk.projects.files.create(
+            project.id,
+            {
+              path: "deno.json",
+              content: customDenoJson,
+              branch_id: branch.id,
+              type: "file" as ProjectFileType,
+            },
+          );
+
+          // Create custom .vtignore
+          await sdk.projects.files.create(
+            project.id,
+            {
+              path: ".vtignore",
+              content: customVtignore,
+              branch_id: branch.id,
+              type: "file" as ProjectFileType,
+            },
+          );
+        });
+
+        await t.step("clone and verify custom config files", async () => {
+          const cloneDir = join(tmpDir, "config-clone");
+          await runVtCommand([
+            "clone",
+            project.name,
+            cloneDir,
+          ], tmpDir);
+
+          // Verify deno.json content
+          const denoJsonContent = await Deno.readTextFile(
+            join(cloneDir, "deno.json"),
+          );
+          assertEquals(
+            denoJsonContent,
+            customDenoJson,
+            "custom deno.json should be preserved",
+          );
+
+          // Verify .vtignore content
+          const vtignoreContent = await Deno.readTextFile(
+            join(cloneDir, ".vtignore"),
+          );
+          assertEquals(
+            vtignoreContent,
+            customVtignore,
+            "custom .vtignore should be preserved",
+          );
+        });
+      });
+    });
+  },
+});
+
+Deno.test({
   name: "clone a newly created project",
   permissions: {
     read: true,

--- a/src/cmd/tests/pull_test.ts
+++ b/src/cmd/tests/pull_test.ts
@@ -16,6 +16,8 @@ Deno.test({
         });
 
         const fullPath = join(tmpDir, project.name);
+        await Deno.remove(join(fullPath, ".vtignore"));
+        await Deno.remove(join(fullPath, "deno.json"));
 
         await t.step("run pull command", async () => {
           const [output] = await runVtCommand(["pull"], fullPath);

--- a/src/cmd/tests/push_test.ts
+++ b/src/cmd/tests/push_test.ts
@@ -65,6 +65,8 @@ Deno.test({
         });
 
         const fullPath = join(tmpDir, project.name);
+        await Deno.remove(join(fullPath, ".vtignore"));
+        await Deno.remove(join(fullPath, "deno.json"));
 
         await t.step("run push command with no changes", async () => {
           const [output] = await runVtCommand(["push"], fullPath);

--- a/src/cmd/tests/status_test.ts
+++ b/src/cmd/tests/status_test.ts
@@ -26,6 +26,8 @@ Deno.test({
         });
 
         const fullPath = join(tmpDir, project.name);
+        await Deno.remove(join(fullPath, ".vtignore"));
+        await Deno.remove(join(fullPath, "deno.json"));
 
         await t.step("make a local change", async () => {
           // Make a local change

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -5,7 +5,6 @@ export const DEFAULT_BRANCH_NAME = "main";
 export const API_KEY_KEY = "VAL_TOWN_API_KEY";
 
 export const ALWAYS_IGNORE_PATTERNS: string[] = [
-  ".vtignore",
   ".vt",
   ".env",
 ];

--- a/src/vt/vt/VTClient.ts
+++ b/src/vt/vt/VTClient.ts
@@ -59,15 +59,19 @@ export default class VTClient {
     options?: { noDenoJson?: boolean },
   ): Promise<void> {
     // Always add the vt ignore file
-    await Deno.writeTextFile(
-      join(this.rootPath, META_IGNORE_FILE_NAME),
-      vtIgnore.text,
-    );
+    const metaIgnoreFile = join(this.rootPath, META_IGNORE_FILE_NAME);
+    if (!await exists(metaIgnoreFile)) {
+      await Deno.writeTextFile(
+        join(this.rootPath, META_IGNORE_FILE_NAME),
+        vtIgnore.text,
+      );
+    }
 
     // Add deno.json unless explicitly disabled
-    if (!options?.noDenoJson) {
+    const denoJsonFile = join(this.rootPath, "deno.json");
+    if (!(options?.noDenoJson) && !await exists(denoJsonFile)) {
       await Deno.writeTextFile(
-        join(this.rootPath, "deno.json"),
+        denoJsonFile,
         JSON.stringify(denoJson, undefined, 2),
       );
     }

--- a/src/vt/vt/editor/vtignore.json
+++ b/src/vt/vt/editor/vtignore.json
@@ -1,3 +1,3 @@
 {
-  "text": "deno.json"
+  "text": "deno.json\n.git\n.DS_Store\nnode_modules\nvendor"
 }

--- a/src/vt/vt/editor/vtignore.json
+++ b/src/vt/vt/editor/vtignore.json
@@ -1,3 +1,3 @@
 {
-  "text": "deno.json\n.git\n.DS_Store\nnode_modules\nvendor"
+  "text": ".git\n.DS_Store\nnode_modules\nvendor"
 }


### PR DESCRIPTION
Add more entries to the default `.vtignore`, and don't ignore the `.vtignore` (so we push the `.vtignore` so that they get it when they clone in the future). The second  part I think is most important.