### PR TITLE
Create directories before doing rename

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/src/cmd/lib/utils.ts
+++ b/src/cmd/lib/utils.ts
@@ -75,7 +75,7 @@ export function formatStatus(
         dirname(file.path),
         styleConfig.color(basename(file.path)),
       ) +
-      ` ${colors.gray((file.similarity * 100).toFixed(2) + "%")}`;
+      ` ${colors.gray("(" + (file.similarity * 100).toFixed(2) + "%)")}`;
   } else {
     // Normal path display for other statuses
     pathDisplay = join(


### PR DESCRIPTION
During a `push`, when a new directory is created and a file is moved into it, during the rename stage of push, we were getting the parent id of each project item using the initial version. We need to use the version *after* adding the directory so that we can get the directory's ID to use as the parent id of the project item.