### PR TITLE
Throttle Pushes to 10 Concurrent Requests

### DIFF
--- a/src/vt/lib/clone.ts
+++ b/src/vt/lib/clone.ts
@@ -75,7 +75,7 @@ export function clone(params: CloneParams): Promise<CloneResult> {
 
             // If the directory is new mark it as created
             if (!(await exists(join(targetDir, file.path)))) {
-              await itemStateChanges.insert({
+              itemStateChanges.insert({
                 type: "directory",
                 path: file.path,
                 status: "created",
@@ -174,7 +174,7 @@ async function createFile(
   }
 
   // Track file status
-  await changes.insert(fileStatus);
+  changes.insert(fileStatus);
 
   // Stop here for dry runs
   if (dryRun) return;


### PR DESCRIPTION
Implemented after accidentally degrading fastify server--previously `vt` would fire all requests for push at the same time. This does it in an async pool so that there's some control.
![image](https://github.com/user-attachments/assets/b3a126ba-7f2e-4782-bd26-43caec75d641)
