### PR TITLE
Graceful Copying

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/src/cmd/lib/utils/displayFileStatus.ts
+++ b/src/cmd/lib/utils/displayFileStatus.ts
@@ -1,8 +1,4 @@
 import { colors } from "@cliffy/ansi/colors";
-import type {
-  ItemStatus,
-  ItemStatusManager,
-} from "../../../vt/lib/utils/ItemStatusManager.ts";
 import {
   ProjectItemColors,
   STATUS_STYLES,
@@ -11,6 +7,10 @@ import {
 } from "~/consts.ts";
 import type { ProjectItemType } from "~/types.ts";
 import { basename, dirname, join } from "@std/path";
+import type {
+  ItemStatus,
+  ItemStatusManager,
+} from "~/vt/lib/utils/ItemStatusManager.ts";
 
 /**
  * Displays file changes and summary information from a FileStateChanges

--- a/src/cmd/lib/utils/displayFileStatus.ts
+++ b/src/cmd/lib/utils/displayFileStatus.ts
@@ -2,7 +2,7 @@ import { colors } from "@cliffy/ansi/colors";
 import type {
   ItemStatus,
   ItemStatusManager,
-} from "~/vt/lib/ItemStatusManager.ts";
+} from "../../../vt/lib/utils/ItemStatusManager.ts";
 import {
   ProjectItemColors,
   STATUS_STYLES,

--- a/src/cmd/tests/branch_test.ts
+++ b/src/cmd/tests/branch_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/branch_test.ts
+++ b/src/cmd/tests/branch_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/checkout_test.ts
+++ b/src/cmd/tests/checkout_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/checkout_test.ts
+++ b/src/cmd/tests/checkout_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/clone_test.ts
+++ b/src/cmd/tests/clone_test.ts
@@ -3,7 +3,7 @@ import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { exists } from "@std/fs";
 import { join } from "@std/path";
 import sdk, { randomProjectName, user } from "~/sdk.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { runVtCommand, streamVtCommand } from "~/cmd/tests/utils.ts";
 import type { ProjectFileType } from "~/types.ts";
 import { deadline, delay } from "@std/async";

--- a/src/cmd/tests/clone_test.ts
+++ b/src/cmd/tests/clone_test.ts
@@ -3,7 +3,7 @@ import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { exists } from "@std/fs";
 import { join } from "@std/path";
 import sdk, { randomProjectName, user } from "~/sdk.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { runVtCommand, streamVtCommand } from "~/cmd/tests/utils.ts";
 import type { ProjectFileType } from "~/types.ts";
 import { deadline, delay } from "@std/async";

--- a/src/cmd/tests/config_test.ts
+++ b/src/cmd/tests/config_test.ts
@@ -1,5 +1,5 @@
 import { assertStringIncludes } from "@std/assert";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";
 import { join } from "@std/path";
 import { exists } from "@std/fs";

--- a/src/cmd/tests/config_test.ts
+++ b/src/cmd/tests/config_test.ts
@@ -1,5 +1,5 @@
 import { assertStringIncludes } from "@std/assert";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";
 import { join } from "@std/path";
 import { exists } from "@std/fs";

--- a/src/cmd/tests/create_test.ts
+++ b/src/cmd/tests/create_test.ts
@@ -3,7 +3,7 @@ import { exists } from "@std/fs";
 import { join } from "@std/path";
 import type ValTown from "@valtown/sdk";
 import sdk, { randomProjectName, user } from "~/sdk.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";
 import { dirIsEmpty } from "~/utils.ts";
 

--- a/src/cmd/tests/create_test.ts
+++ b/src/cmd/tests/create_test.ts
@@ -3,7 +3,7 @@ import { exists } from "@std/fs";
 import { join } from "@std/path";
 import type ValTown from "@valtown/sdk";
 import sdk, { randomProjectName, user } from "~/sdk.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";
 import { dirIsEmpty } from "~/utils.ts";
 

--- a/src/cmd/tests/delete_test.ts
+++ b/src/cmd/tests/delete_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { join } from "@std/path";
 import { runVtCommand, runVtProc } from "~/cmd/tests/utils.ts";
 import { assert, assertStringIncludes } from "@std/assert";

--- a/src/cmd/tests/delete_test.ts
+++ b/src/cmd/tests/delete_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { join } from "@std/path";
 import { runVtCommand, runVtProc } from "~/cmd/tests/utils.ts";
 import { assert, assertStringIncludes } from "@std/assert";

--- a/src/cmd/tests/list_test.ts
+++ b/src/cmd/tests/list_test.ts
@@ -1,5 +1,5 @@
 import { runVtCommand } from "~/cmd/tests/utils.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { assertStringIncludes } from "@std/assert";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 

--- a/src/cmd/tests/list_test.ts
+++ b/src/cmd/tests/list_test.ts
@@ -1,5 +1,5 @@
 import { runVtCommand } from "~/cmd/tests/utils.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { assertStringIncludes } from "@std/assert";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 

--- a/src/cmd/tests/pull_test.ts
+++ b/src/cmd/tests/pull_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/pull_test.ts
+++ b/src/cmd/tests/pull_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/push_test.ts
+++ b/src/cmd/tests/push_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/push_test.ts
+++ b/src/cmd/tests/push_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/remix_test.ts
+++ b/src/cmd/tests/remix_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { join } from "@std/path";
 import sdk, { user } from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/remix_test.ts
+++ b/src/cmd/tests/remix_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { join } from "@std/path";
 import sdk, { user } from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/status_test.ts
+++ b/src/cmd/tests/status_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/status_test.ts
+++ b/src/cmd/tests/status_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";

--- a/src/cmd/tests/utils.ts
+++ b/src/cmd/tests/utils.ts
@@ -1,7 +1,7 @@
 import { join } from "@std/path";
 import stripAnsi from "strip-ansi";
 import { ENTRYPOINT_NAME } from "~/consts.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 
 /**
  * Creates and spawns a Deno child process for the vt.ts script.

--- a/src/cmd/tests/utils.ts
+++ b/src/cmd/tests/utils.ts
@@ -1,7 +1,7 @@
 import { join } from "@std/path";
 import stripAnsi from "strip-ansi";
 import { ENTRYPOINT_NAME } from "~/consts.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 
 /**
  * Creates and spawns a Deno child process for the vt.ts script.

--- a/src/cmd/tests/watch_test.ts
+++ b/src/cmd/tests/watch_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
 import { join } from "@std/path";
 import { assert } from "@std/assert";
 import { exists } from "@std/fs";

--- a/src/cmd/tests/watch_test.ts
+++ b/src/cmd/tests/watch_test.ts
@@ -1,5 +1,5 @@
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
-import { doWithTempDir } from "../../vt/lib/utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { join } from "@std/path";
 import { assert } from "@std/assert";
 import { exists } from "@std/fs";

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -72,6 +72,7 @@ export async function doWithSpinner<T>(
 
     return await callback(spinner);
   } catch (e) {
+    console.log(e);
     // Use the provided or default error cleaning function
     const cleanedErrorMessage = cleanError(e);
 

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -72,7 +72,6 @@ export async function doWithSpinner<T>(
 
     return await callback(spinner);
   } catch (e) {
-    console.log(e);
     // Use the provided or default error cleaning function
     const cleanedErrorMessage = cleanError(e);
 

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,7 +2,7 @@ import { colors } from "@cliffy/ansi/colors";
 import type { ProjectItemType } from "~/types.ts";
 import { join } from "@std/path";
 import xdg from "xdg-portable";
-import type { ItemWarning } from "~/vt/lib/ItemStatusManager.ts";
+import type { ItemWarning } from "./vt/lib/utils/ItemStatusManager.ts";
 
 export const DEFAULT_BRANCH_NAME = "main";
 export const PROGRAM_NAME = "vt";

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,7 +2,7 @@ import { colors } from "@cliffy/ansi/colors";
 import type { ProjectItemType } from "~/types.ts";
 import { join } from "@std/path";
 import xdg from "xdg-portable";
-import type { ItemWarning } from "./vt/lib/utils/ItemStatusManager.ts";
+import type { ItemWarning } from "~/vt/lib/utils/ItemStatusManager.ts";
 
 export const DEFAULT_BRANCH_NAME = "main";
 export const PROGRAM_NAME = "vt";

--- a/src/vt/lib/checkout.ts
+++ b/src/vt/lib/checkout.ts
@@ -2,11 +2,11 @@ import sdk from "~/sdk.ts";
 import type ValTown from "@valtown/sdk";
 import { pull } from "~/vt/lib/pull.ts";
 import { join, relative } from "@std/path";
-import { copy, exists, walk } from "@std/fs";
+import { exists, walk } from "@std/fs";
 import { getProjectItemType, shouldIgnore } from "~/vt/lib/paths.ts";
 import { listProjectItems } from "~/sdk.ts";
-import { ItemStatusManager } from "~/vt/lib/ItemStatusManager.ts";
-import { doAtomically } from "~/vt/lib/utils.ts";
+import { ItemStatusManager } from "./utils/ItemStatusManager.ts";
+import { doAtomically, gracefulRecursiveCopy } from "./utils/misc.ts";
 
 /**
  * Result of a checkout operation containing branch information and file
@@ -155,10 +155,9 @@ async function handleBranchCheckout(
 ): Promise<CheckoutResult> {
   return await doAtomically(
     async (tmpDir) => {
-      // Copy over the current state for accurate delta tracking
-      await copy(params.targetDir, tmpDir, {
-        preserveTimestamps: true,
+      await gracefulRecursiveCopy(params.targetDir, tmpDir, {
         overwrite: true,
+        preserveTimestamps: true,
       });
 
       const fileStateChanges = new ItemStatusManager();

--- a/src/vt/lib/checkout.ts
+++ b/src/vt/lib/checkout.ts
@@ -5,8 +5,8 @@ import { join, relative } from "@std/path";
 import { exists, walk } from "@std/fs";
 import { getProjectItemType, shouldIgnore } from "~/vt/lib/paths.ts";
 import { listProjectItems } from "~/sdk.ts";
-import { ItemStatusManager } from "./utils/ItemStatusManager.ts";
-import { doAtomically, gracefulRecursiveCopy } from "./utils/misc.ts";
+import { ItemStatusManager } from "~/vt/lib/utils/ItemStatusManager.ts";
+import { doAtomically, gracefulRecursiveCopy } from "~/vt/lib/utils/misc.ts";
 
 /**
  * Result of a checkout operation containing branch information and file

--- a/src/vt/lib/checkout.ts
+++ b/src/vt/lib/checkout.ts
@@ -244,7 +244,14 @@ async function handleBranchCheckout(
       // Perform the deletions
       await Promise.all(pathsToDelete.map(async (path) => {
         if (await exists(path)) {
-          await Deno.remove(path, { recursive: true });
+          try {
+            await Deno.remove(path, { recursive: true });
+          } catch (e) {
+            if (e instanceof Deno.errors.NotFound) {
+              // Ignore if the file was already deleted
+            }
+            throw e;
+          }
         }
       }));
 

--- a/src/vt/lib/checkout.ts
+++ b/src/vt/lib/checkout.ts
@@ -2,7 +2,7 @@ import sdk from "~/sdk.ts";
 import type ValTown from "@valtown/sdk";
 import { pull } from "~/vt/lib/pull.ts";
 import { join, relative } from "@std/path";
-import { exists, walk } from "@std/fs";
+import { walk } from "@std/fs";
 import { getProjectItemType, shouldIgnore } from "~/vt/lib/paths.ts";
 import { listProjectItems } from "~/sdk.ts";
 import { ItemStatusManager } from "~/vt/lib/utils/ItemStatusManager.ts";
@@ -243,15 +243,10 @@ async function handleBranchCheckout(
 
       // Perform the deletions
       await Promise.all(pathsToDelete.map(async (path) => {
-        if (await exists(path)) {
-          try {
-            await Deno.remove(path, { recursive: true });
-          } catch (e) {
-            if (e instanceof Deno.errors.NotFound) {
-              // Ignore if the file was already deleted
-            }
-            throw e;
-          }
+        try {
+          await Deno.remove(path, { recursive: true });
+        } catch (e) {
+          if (!(e instanceof Deno.errors.NotFound)) throw e;
         }
       }));
 

--- a/src/vt/lib/clone.ts
+++ b/src/vt/lib/clone.ts
@@ -1,14 +1,14 @@
 import sdk, { listProjectItems } from "~/sdk.ts";
 import { shouldIgnore } from "~/vt/lib/paths.ts";
 import { ensureDir, exists } from "@std/fs";
-import { doAtomically, isFileModified } from "./utils/misc.ts";
 import { dirname } from "@std/path/dirname";
 import { join } from "@std/path";
 import type ValTown from "@valtown/sdk";
+import { doAtomically, isFileModified } from "~/vt/lib/utils/misc.ts";
 import {
+ItemStatusManager,
   type ItemStatus,
-  ItemStatusManager,
-} from "./utils/ItemStatusManager.ts";
+} from "~/vt/lib/utils/ItemStatusManager.ts";
 
 /**
  * Result of a clone operation.
@@ -75,7 +75,7 @@ export function clone(params: CloneParams): Promise<CloneResult> {
 
             // If the directory is new mark it as created
             if (!(await exists(join(targetDir, file.path)))) {
-              await itemStateChanges.insert({
+              itemStateChanges.insert({
                 type: "directory",
                 path: file.path,
                 status: "created",
@@ -174,7 +174,7 @@ async function createFile(
   }
 
   // Track file status
-  await changes.insert(fileStatus);
+  changes.insert(fileStatus);
 
   // Stop here for dry runs
   if (dryRun) return;

--- a/src/vt/lib/clone.ts
+++ b/src/vt/lib/clone.ts
@@ -1,14 +1,14 @@
 import sdk, { listProjectItems } from "~/sdk.ts";
 import { shouldIgnore } from "~/vt/lib/paths.ts";
 import { ensureDir, exists } from "@std/fs";
-import { doAtomically, isFileModified } from "~/vt/lib/utils.ts";
+import { doAtomically, isFileModified } from "./utils/misc.ts";
 import { dirname } from "@std/path/dirname";
 import { join } from "@std/path";
 import type ValTown from "@valtown/sdk";
 import {
   type ItemStatus,
   ItemStatusManager,
-} from "~/vt/lib/ItemStatusManager.ts";
+} from "./utils/ItemStatusManager.ts";
 
 /**
  * Result of a clone operation.

--- a/src/vt/lib/clone.ts
+++ b/src/vt/lib/clone.ts
@@ -6,8 +6,8 @@ import { join } from "@std/path";
 import type ValTown from "@valtown/sdk";
 import { doAtomically, isFileModified } from "~/vt/lib/utils/misc.ts";
 import {
-ItemStatusManager,
   type ItemStatus,
+  ItemStatusManager,
 } from "~/vt/lib/utils/ItemStatusManager.ts";
 
 /**

--- a/src/vt/lib/create.ts
+++ b/src/vt/lib/create.ts
@@ -1,9 +1,9 @@
 import { push } from "~/vt/lib/push.ts";
 import sdk, { branchNameToBranch } from "~/sdk.ts";
-import type { ItemStatusManager } from "./utils/ItemStatusManager.ts";
 import type { ProjectPrivacy } from "~/types.ts";
 import { DEFAULT_BRANCH_NAME } from "~/consts.ts";
 import { ensureDir } from "@std/fs";
+import type { ItemStatusManager } from "~/vt/lib/utils/ItemStatusManager.ts";
 
 /**
  * Result of a checkout operation containing branch information and file

--- a/src/vt/lib/create.ts
+++ b/src/vt/lib/create.ts
@@ -1,6 +1,6 @@
 import { push } from "~/vt/lib/push.ts";
 import sdk, { branchNameToBranch } from "~/sdk.ts";
-import type { ItemStatusManager } from "~/vt/lib/ItemStatusManager.ts";
+import type { ItemStatusManager } from "./utils/ItemStatusManager.ts";
 import type { ProjectPrivacy } from "~/types.ts";
 import { DEFAULT_BRANCH_NAME } from "~/consts.ts";
 import { ensureDir } from "@std/fs";

--- a/src/vt/lib/pull.ts
+++ b/src/vt/lib/pull.ts
@@ -2,12 +2,12 @@ import { join, relative } from "@std/path";
 import { copy, exists, walk } from "@std/fs";
 import { getProjectItemType, shouldIgnore } from "~/vt/lib/paths.ts";
 import { listProjectItems } from "~/sdk.ts";
-import { doAtomically } from "~/vt/lib/utils.ts";
+import { doAtomically } from "./utils/misc.ts";
 import { clone } from "~/vt/lib/clone.ts";
 import {
   type ItemStatus,
   ItemStatusManager,
-} from "~/vt/lib/ItemStatusManager.ts";
+} from "./utils/ItemStatusManager.ts";
 
 /**
  * Parameters for pulling latest changes from a Val Town project into a vt folder.

--- a/src/vt/lib/pull.ts
+++ b/src/vt/lib/pull.ts
@@ -2,12 +2,12 @@ import { join, relative } from "@std/path";
 import { copy, exists, walk } from "@std/fs";
 import { getProjectItemType, shouldIgnore } from "~/vt/lib/paths.ts";
 import { listProjectItems } from "~/sdk.ts";
-import { doAtomically } from "./utils/misc.ts";
 import { clone } from "~/vt/lib/clone.ts";
+import { doAtomically } from "~/vt/lib/utils/misc.ts";
 import {
   type ItemStatus,
   ItemStatusManager,
-} from "./utils/ItemStatusManager.ts";
+} from "~/vt/lib/utils/ItemStatusManager.ts";
 
 /**
  * Parameters for pulling latest changes from a Val Town project into a vt folder.

--- a/src/vt/lib/pull.ts
+++ b/src/vt/lib/pull.ts
@@ -1,5 +1,5 @@
 import { join, relative } from "@std/path";
-import { exists, walk } from "@std/fs";
+import { walk } from "@std/fs";
 import { getProjectItemType, shouldIgnore } from "~/vt/lib/paths.ts";
 import { listProjectItems } from "~/sdk.ts";
 import { clone } from "~/vt/lib/clone.ts";
@@ -122,8 +122,10 @@ export function pull(params: PullParams): Promise<ItemStatusManager> {
 
       // Perform the deletions
       await Promise.all(pathsToDelete.map(async (path) => {
-        if (await exists(path)) {
+        try {
           await Deno.remove(path, { recursive: true });
+        } catch (e) {
+          if (!(e instanceof Deno.errors.NotFound)) throw e;
         }
       }));
       return [changes, !dryRun];

--- a/src/vt/lib/pull.ts
+++ b/src/vt/lib/pull.ts
@@ -1,9 +1,9 @@
 import { join, relative } from "@std/path";
-import { copy, exists, walk } from "@std/fs";
+import { exists, walk } from "@std/fs";
 import { getProjectItemType, shouldIgnore } from "~/vt/lib/paths.ts";
 import { listProjectItems } from "~/sdk.ts";
 import { clone } from "~/vt/lib/clone.ts";
-import { doAtomically } from "~/vt/lib/utils/misc.ts";
+import { doAtomically, gracefulRecursiveCopy } from "~/vt/lib/utils/misc.ts";
 import {
   type ItemStatus,
   ItemStatusManager,
@@ -60,7 +60,7 @@ export function pull(params: PullParams): Promise<ItemStatusManager> {
       // dry run the purpose here is to ensure that clone reports back the
       // proper status for modified files (e.g. if they existed and would be
       // changed then they're modified)
-      await copy(targetDir, tmpDir, {
+      await gracefulRecursiveCopy(targetDir, tmpDir, {
         preserveTimestamps: true,
         overwrite: true,
       });

--- a/src/vt/lib/push.ts
+++ b/src/vt/lib/push.ts
@@ -1,7 +1,3 @@
-import {
-  getItemWarnings,
-  ItemStatusManager,
-} from "./utils/ItemStatusManager.ts";
 import type { ProjectFileType, ProjectItemType } from "~/types.ts";
 import sdk, {
   getLatestVersion,
@@ -13,6 +9,10 @@ import { basename, dirname, join } from "@std/path";
 import { assert } from "@std/assert";
 import { exists } from "@std/fs/exists";
 import ValTown from "@valtown/sdk";
+import {
+  getItemWarnings,
+  ItemStatusManager,
+} from "~/vt/lib/utils/ItemStatusManager.ts";
 
 export interface PushResult {
   /** Changes made to project items during the push process */

--- a/src/vt/lib/push.ts
+++ b/src/vt/lib/push.ts
@@ -1,7 +1,7 @@
 import {
   getItemWarnings,
   ItemStatusManager,
-} from "~/vt/lib/ItemStatusManager.ts";
+} from "./utils/ItemStatusManager.ts";
 import type { ProjectFileType, ProjectItemType } from "~/types.ts";
 import sdk, {
   getLatestVersion,

--- a/src/vt/lib/remix.ts
+++ b/src/vt/lib/remix.ts
@@ -1,4 +1,4 @@
-import { doAtomically } from "~/vt/lib/utils.ts";
+import { doAtomically } from "./utils/misc.ts";
 import { clone } from "~/vt/lib/clone.ts";
 import { create } from "~/vt/lib/create.ts";
 import sdk, {
@@ -6,7 +6,7 @@ import sdk, {
   getLatestVersion,
   listProjectItems,
 } from "~/sdk.ts";
-import { ItemStatusManager } from "~/vt/lib/ItemStatusManager.ts";
+import { ItemStatusManager } from "./utils/ItemStatusManager.ts";
 import { DEFAULT_BRANCH_NAME, DEFAULT_PROJECT_PRIVACY } from "~/consts.ts";
 import type { ProjectPrivacy } from "~/types.ts";
 

--- a/src/vt/lib/remix.ts
+++ b/src/vt/lib/remix.ts
@@ -1,4 +1,3 @@
-import { doAtomically } from "./utils/misc.ts";
 import { clone } from "~/vt/lib/clone.ts";
 import { create } from "~/vt/lib/create.ts";
 import sdk, {
@@ -6,9 +5,10 @@ import sdk, {
   getLatestVersion,
   listProjectItems,
 } from "~/sdk.ts";
-import { ItemStatusManager } from "./utils/ItemStatusManager.ts";
 import { DEFAULT_BRANCH_NAME, DEFAULT_PROJECT_PRIVACY } from "~/consts.ts";
 import type { ProjectPrivacy } from "~/types.ts";
+import { ItemStatusManager } from "~/vt/lib/utils/ItemStatusManager.ts";
+import { doAtomically } from "~/vt/lib/utils/misc.ts";
 
 /**
  * Result of remixing a project.

--- a/src/vt/lib/status.ts
+++ b/src/vt/lib/status.ts
@@ -2,7 +2,6 @@ import sdk, { listProjectItems } from "~/sdk.ts";
 import { getProjectItemType, shouldIgnore } from "~/vt/lib/paths.ts";
 import * as fs from "@std/fs";
 import * as path from "@std/path";
-import { isFileModified } from "./utils/misc.ts";
 import {
   type CreatedItemStatus,
   type DeletedItemStatus,
@@ -11,8 +10,9 @@ import {
   ItemStatusManager,
   type ModifiedItemStatus,
   type NotModifiedItemStatus,
-} from "./utils/ItemStatusManager.ts";
+} from "~/vt/lib/utils/ItemStatusManager.ts";
 import { join } from "@std/path";
+import { isFileModified } from "~/vt/lib/utils/misc.ts";
 
 /**
  * Parameters for scanning a directory and determining the status of files compared to the Val Town project.

--- a/src/vt/lib/status.ts
+++ b/src/vt/lib/status.ts
@@ -2,7 +2,7 @@ import sdk, { listProjectItems } from "~/sdk.ts";
 import { getProjectItemType, shouldIgnore } from "~/vt/lib/paths.ts";
 import * as fs from "@std/fs";
 import * as path from "@std/path";
-import { isFileModified } from "~/vt/lib/utils.ts";
+import { isFileModified } from "./utils/misc.ts";
 import {
   type CreatedItemStatus,
   type DeletedItemStatus,
@@ -11,7 +11,7 @@ import {
   ItemStatusManager,
   type ModifiedItemStatus,
   type NotModifiedItemStatus,
-} from "~/vt/lib/ItemStatusManager.ts";
+} from "./utils/ItemStatusManager.ts";
 import { join } from "@std/path";
 
 /**

--- a/src/vt/lib/tests/checkout_test.ts
+++ b/src/vt/lib/tests/checkout_test.ts
@@ -5,7 +5,7 @@ import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { exists } from "@std/fs";
 import type ValTown from "@valtown/sdk";
-import { doWithTempDir } from "../utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 
 Deno.test({
   name: "test cross branch checkout",

--- a/src/vt/lib/tests/checkout_test.ts
+++ b/src/vt/lib/tests/checkout_test.ts
@@ -5,7 +5,7 @@ import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { exists } from "@std/fs";
 import type ValTown from "@valtown/sdk";
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../utils/doWithTempDir.ts";
 
 Deno.test({
   name: "test cross branch checkout",

--- a/src/vt/lib/tests/clone_test.ts
+++ b/src/vt/lib/tests/clone_test.ts
@@ -1,4 +1,4 @@
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../utils/doWithTempDir.ts";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 import sdk from "~/sdk.ts";
 import { clone } from "~/vt/lib/clone.ts";

--- a/src/vt/lib/tests/clone_test.ts
+++ b/src/vt/lib/tests/clone_test.ts
@@ -1,4 +1,4 @@
-import { doWithTempDir } from "../utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 import sdk from "~/sdk.ts";
 import { clone } from "~/vt/lib/clone.ts";

--- a/src/vt/lib/tests/pull_test.ts
+++ b/src/vt/lib/tests/pull_test.ts
@@ -1,4 +1,4 @@
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../utils/doWithTempDir.ts";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 import sdk, { getLatestVersion } from "~/sdk.ts";
 import { pull } from "~/vt/lib/pull.ts";

--- a/src/vt/lib/tests/pull_test.ts
+++ b/src/vt/lib/tests/pull_test.ts
@@ -1,4 +1,4 @@
-import { doWithTempDir } from "../utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 import sdk, { getLatestVersion } from "~/sdk.ts";
 import { pull } from "~/vt/lib/pull.ts";

--- a/src/vt/lib/tests/push_test.ts
+++ b/src/vt/lib/tests/push_test.ts
@@ -1,4 +1,3 @@
-import { doWithTempDir } from "../utils/doWithTempDir.ts";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 import sdk, {
   getLatestVersion,
@@ -8,6 +7,7 @@ import sdk, {
 import { push } from "~/vt/lib/push.ts";
 import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 
 Deno.test({
   name: "test moving file from subdirectory to root",
@@ -732,6 +732,138 @@ Deno.test({
           );
           assert(!largeFileExists, "too large file should NOT exist on server");
         });
+      });
+    });
+  },
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "test push with read-only files",
+  permissions: {
+    read: true,
+    write: true,
+    net: true,
+    env: true,
+  },
+  async fn(t) {
+    await doWithNewProject(async ({ project, branch }) => {
+      await doWithTempDir(async (tempDir) => {
+        // Create multiple files - some will be made read-only
+        const normalFilePath = join(tempDir, "writable.txt");
+        const readOnlyFilePath = join(tempDir, "readonly.txt");
+        const anotherFilePath = join(tempDir, "another.txt");
+
+        await t.step("create initial files and push", async () => {
+          // Create the files with initial content
+          await Deno.writeTextFile(normalFilePath, "writable file content");
+          await Deno.writeTextFile(readOnlyFilePath, "readonly file content");
+          await Deno.writeTextFile(anotherFilePath, "another file content");
+
+          // First push to establish files on the server
+          const { itemStateChanges: initialPush } = await push({
+            targetDir: tempDir,
+            projectId: project.id,
+            branchId: branch.id,
+          });
+
+          // Verify all files were created successfully
+          assertEquals(
+            initialPush.created.length,
+            3,
+            "all three files should be created",
+          );
+
+          // Make one file read-only (no write permission)
+          await Deno.chmod(readOnlyFilePath, 0o444);
+        });
+
+        await t.step("modify writable files and push again", async () => {
+          // Modify only the writable files
+          await Deno.writeTextFile(normalFilePath, "updated writable content");
+          await Deno.writeTextFile(anotherFilePath, "updated another content");
+
+          // Try to push all changes
+          const { itemStateChanges: secondPush } = await push({
+            targetDir: tempDir,
+            projectId: project.id,
+            branchId: branch.id,
+          });
+
+          // Verify push succeeded with correct file states
+          // We expect the read-only file to be in not_modified state
+          // and the two writable files to be in modified state
+          const readOnlyFile = secondPush.all()
+            .find((item) => item.path === "readonly.txt");
+          const writableFile = secondPush.all()
+            .find((item) => item.path === "writable.txt");
+          const anotherFile = secondPush.all()
+            .find((item) => item.path === "another.txt");
+
+          assert(readOnlyFile, "read-only file should be in status results");
+          assert(writableFile, "writable file should be in status results");
+          assert(anotherFile, "another file should be in status results");
+
+          assertEquals(
+            readOnlyFile.status,
+            "not_modified",
+            "read-only file should be not modified",
+          );
+          assertEquals(
+            writableFile.status,
+            "modified",
+            "writable file should be modified",
+          );
+          assertEquals(
+            anotherFile.status,
+            "modified",
+            "another file should be modified",
+          );
+        });
+
+        await t.step("verify server state after push", async () => {
+          // Check content on the server to verify the push succeeded
+          const writableContent = await sdk.projects.files
+            .getContent(project.id, {
+              path: "writable.txt",
+              branch_id: branch.id,
+            })
+            .then((resp) => resp.text());
+
+          const readOnlyContent = await sdk.projects.files
+            .getContent(project.id, {
+              path: "readonly.txt",
+              branch_id: branch.id,
+            })
+            .then((resp) => resp.text());
+
+          const anotherContent = await sdk.projects.files
+            .getContent(project.id, {
+              path: "another.txt",
+              branch_id: branch.id,
+            })
+            .then((resp) => resp.text());
+
+          // Verify the content matches what we expect
+          assertEquals(
+            writableContent,
+            "updated writable content",
+            "Writable file content should be updated on server",
+          );
+          assertEquals(
+            readOnlyContent,
+            "readonly file content",
+            "read-only file content should remain unchanged",
+          );
+          assertEquals(
+            anotherContent,
+            "updated another content",
+            "another file content should be updated on server",
+          );
+        });
+
+        // Clean up by making the file writable again for proper deletion
+        await Deno.chmod(readOnlyFilePath, 0o666);
       });
     });
   },

--- a/src/vt/lib/tests/push_test.ts
+++ b/src/vt/lib/tests/push_test.ts
@@ -1,4 +1,4 @@
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../utils/doWithTempDir.ts";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 import sdk, {
   getLatestVersion,

--- a/src/vt/lib/tests/remix_test.ts
+++ b/src/vt/lib/tests/remix_test.ts
@@ -1,4 +1,4 @@
-import { doWithTempDir } from "../utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 import sdk, { user } from "~/sdk.ts";
 import { assert, assertEquals } from "@std/assert";

--- a/src/vt/lib/tests/remix_test.ts
+++ b/src/vt/lib/tests/remix_test.ts
@@ -1,4 +1,4 @@
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../utils/doWithTempDir.ts";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 import sdk, { user } from "~/sdk.ts";
 import { assert, assertEquals } from "@std/assert";

--- a/src/vt/lib/tests/status_test.ts
+++ b/src/vt/lib/tests/status_test.ts
@@ -1,4 +1,4 @@
-import { doWithTempDir } from "../utils/doWithTempDir.ts";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 import sdk, { getLatestVersion } from "~/sdk.ts";
 import { assertEquals } from "@std/assert";

--- a/src/vt/lib/tests/status_test.ts
+++ b/src/vt/lib/tests/status_test.ts
@@ -1,10 +1,10 @@
-import { doWithTempDir } from "~/vt/lib/utils.ts";
+import { doWithTempDir } from "../utils/doWithTempDir.ts";
 import { doWithNewProject } from "~/vt/lib/tests/utils.ts";
 import sdk, { getLatestVersion } from "~/sdk.ts";
 import { assertEquals } from "@std/assert";
 import { join } from "@std/path";
 import { status } from "~/vt/lib/status.ts";
-import type { ItemStatusManager } from "~/vt/lib/ItemStatusManager.ts";
+import type { ItemStatusManager } from "../utils/ItemStatusManager.ts";
 
 Deno.test({
   name: "test status detects binary files",

--- a/src/vt/lib/utils/ItemStatusManager.ts
+++ b/src/vt/lib/utils/ItemStatusManager.ts
@@ -476,8 +476,8 @@ export class ItemStatusManager {
         // Content is empty if either is a directory, so we can use ! here
         // since we already checked that
         // The creation should always be local (since we are detecting a local rename)
-        const newItemContent = newItem.content!;
-        const oldItemContent = oldItem.content!;
+        const newItemContent = newItem.content || "";
+        const oldItemContent = oldItem.content || "";
 
         // If newItemContent differs in length by more than
         // RENAME_DETECTION_THRESHOLD% of oldItemContent, skip it since it

--- a/src/vt/lib/utils/misc.ts
+++ b/src/vt/lib/utils/misc.ts
@@ -1,4 +1,5 @@
-import { copy, ensureDir, exists } from "@std/fs";
+import { ensureDir, exists, walk } from "@std/fs";
+import { join, relative } from "@std/path";
 
 /**
  * Creates a temporary directory and returns it with a cleanup function.
@@ -29,27 +30,6 @@ export async function withTempDir(
 }
 
 /**
- * Executes an operation in a temporary directory and ensures cleanup.
- *
- * @param op - Function that takes a temporary directory path and returns a Promise
- * @param options - Options for the operation
- * @param options.prefix - Optional prefix for the temporary directory name (defaults to "vt_")
- * @returns Promise that resolves to the result of the operation
- */
-export async function doWithTempDir<T>(
-  op: (tmpDir: string) => Promise<T>,
-  options: { prefix?: string } = { prefix: "vt_" },
-): Promise<T> {
-  const { tempDir, cleanup } = await withTempDir(options);
-
-  try {
-    return await op(tempDir);
-  } finally {
-    await cleanup();
-  }
-}
-
-/**
   * Create a directory atomically by first doing logic to create it in a temp
   * directory, and then moving it to a destination afterwards.
   *
@@ -74,7 +54,7 @@ export async function doAtomically<T>(
 
     if (copyBack) {
       await ensureDir(targetDir);
-      await copy(tempDir, targetDir, {
+      await gracefulRecursiveCopy(tempDir, targetDir, {
         overwrite: true,
         preserveTimestamps: true,
       });
@@ -110,4 +90,76 @@ export function isFileModified({
 
   // If mtime indicates a possible change, check content
   return srcContent !== dstContent;
+}
+
+/**
+ * Executes an operation in a temporary directory and ensures cleanup.
+ *
+ * @param op - Function that takes a temporary directory path and returns a Promise
+ * @param options - Options for the operation
+ * @param options.prefix - Optional prefix for the temporary directory name (defaults to "vt_")
+ * @returns Promise that resolves to the result of the operation
+ */
+
+export async function doWithTempDir<T>(
+  op: (tmpDir: string) => Promise<T>,
+  options: { prefix?: string } = { prefix: "vt_" },
+): Promise<T> {
+  const { tempDir, cleanup } = await withTempDir(options);
+
+  try {
+    return await op(tempDir);
+  } finally {
+    await cleanup();
+  }
+}
+
+/**
+ * Recursively copies files and directories from `src` to `dst`.
+ *
+ * Any errors during copying (e.g. permission issues, file locks) are caught and stored,
+ * and the function continues processing remaining files.
+ *
+ * @param src Source directory path
+ * @param dst Destination directory path
+ * @param options Options for the copy operation
+ * @param options.overwrite Whether to overwrite existing files (default: false)
+ * @param options.preserveTimestamps Whether to preserve file timestamps (default: true)
+ * @returns An object containing a list of file paths that failed to copy
+ */
+export async function gracefulRecursiveCopy(
+  src: string,
+  dst: string,
+  options: {
+    overwrite?: boolean;
+    preserveTimestamps?: boolean;
+  } = { overwrite: false, preserveTimestamps: false },
+): Promise<{ failed: string[] }> {
+  const failed: string[] = [];
+
+  for await (const entry of walk(src)) {
+    const relPath = relative(src, entry.path);
+    const dstPath = join(dst, relPath);
+
+    try {
+      if (entry.isDirectory) {
+        await ensureDir(dstPath);
+      } else if (entry.isFile) {
+        const entryStat = await Deno.stat(entry.path);
+        await ensureDir(join(dstPath, ".."));
+        await Deno.copyFile(entry.path, dstPath);
+        if (entryStat.mtime && options.preserveTimestamps) {
+          await Deno.utime(
+            dstPath,
+            entryStat.atime || entryStat.mtime,
+            entryStat.mtime,
+          );
+        }
+      }
+    } catch {
+      failed.push(entry.path);
+    }
+  }
+
+  return { failed };
 }

--- a/src/vt/vt/VTClient.ts
+++ b/src/vt/vt/VTClient.ts
@@ -20,7 +20,6 @@ import {
   META_IGNORE_FILE_NAME,
 } from "~/consts.ts";
 import { status } from "~/vt/lib/status.ts";
-import type { ItemStatusManager } from "../lib/utils/ItemStatusManager.ts";
 import { exists } from "@std/fs";
 import ValTown from "@valtown/sdk";
 import { dirIsEmpty } from "~/utils.ts";
@@ -28,6 +27,7 @@ import VTConfig from "~/vt/VTConfig.ts";
 import { remix } from "~/vt/lib/remix.ts";
 import type { ProjectPrivacy } from "~/types.ts";
 import { create } from "~/vt/lib/create.ts";
+import type { ItemStatusManager } from "~/vt/lib/utils/ItemStatusManager.ts";
 
 /**
  * The VTClient class is an abstraction on a VT directory that exposes

--- a/src/vt/vt/VTClient.ts
+++ b/src/vt/vt/VTClient.ts
@@ -20,7 +20,7 @@ import {
   META_IGNORE_FILE_NAME,
 } from "~/consts.ts";
 import { status } from "~/vt/lib/status.ts";
-import type { ItemStatusManager } from "~/vt/lib/ItemStatusManager.ts";
+import type { ItemStatusManager } from "../lib/utils/ItemStatusManager.ts";
 import { exists } from "@std/fs";
 import ValTown from "@valtown/sdk";
 import { dirIsEmpty } from "~/utils.ts";


### PR DESCRIPTION
Fixes a bug where we copy files to a temp dir when we don't have permissions to write or update the time of that file. Do this by reimplementing copy ourselves to be more graceful.