### PR TITLE
Various Performance Boosts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
           VAL_TOWN_API_KEY: ${{ secrets.VAL_TOWN_API_KEY }}
 
   test-mac:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/deno.json
+++ b/deno.json
@@ -10,6 +10,7 @@
     "test": "deno task test:lib && deno task test:cmd",
     "test:cmd": "env DENO_NO_PROMPT=1 deno test -A --trace-leaks --fail-fast ./src/cmd",
     "test:lib": "env DENO_NO_PROMPT=1 deno test -A --trace-leaks --parallel ./src/vt/lib",
+    "profile": "deno run -A ./profile.ts ./vt.ts",
     "check": "env DENO_NO_PROMPT=1 deno check .",
     "fmt:check": "env DENO_NO_PROMPT=1 deno fmt --check"
   },

--- a/deno.lock
+++ b/deno.lock
@@ -319,6 +319,31 @@
       "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="
     }
   },
+  "remote": {
+    "https://deno.land/std@0.118.0/_util/assert.ts": "2f868145a042a11d5ad0a3c748dcf580add8a0dbc0e876eaa0026303a5488f58",
+    "https://deno.land/std@0.118.0/_util/os.ts": "dfb186cc4e968c770ab6cc3288bd65f4871be03b93beecae57d657232ecffcac",
+    "https://deno.land/std@0.118.0/fs/_util.ts": "f2ce811350236ea8c28450ed822a5f42a0892316515b1cd61321dec13569c56b",
+    "https://deno.land/std@0.118.0/fs/empty_dir.ts": "5f08b263dd064dc7917c4bbeb13de0f5505a664b9cdfe312fa86e7518cfaeb84",
+    "https://deno.land/std@0.118.0/fs/ensure_dir.ts": "b7c103dc41a3d1dbbb522bf183c519c37065fdc234831a4a0f7d671b1ed5fea7",
+    "https://deno.land/std@0.118.0/fs/ensure_file.ts": "c06031af24368e80c330897e4b8e9109efc8602ffabc8f3e2306be07529e1d13",
+    "https://deno.land/std@0.118.0/fs/ensure_link.ts": "26e54363508b822afd87a3f6e873bbbcd6b5993dd638f8170758c16262a75065",
+    "https://deno.land/std@0.118.0/fs/ensure_symlink.ts": "c07b6d19ef58b6f5c671ffa942e7f9be50315f4f78e2f9f511626fd2e13beccc",
+    "https://deno.land/std@0.118.0/fs/eol.ts": "afaebaaac36f48c423b920c836551997715672b80a0fee9aa7667c181a94f2df",
+    "https://deno.land/std@0.118.0/fs/exists.ts": "c3c3335a212bd945bb75df379096ab57fb6c86598fa273dfb24da3b3939a951e",
+    "https://deno.land/std@0.118.0/fs/expand_glob.ts": "f6f64ef54addcc84c9012d6dfcf66d39ecc2565e40c4d2b7644d585fe4d12a04",
+    "https://deno.land/std@0.118.0/fs/mod.ts": "2bf5468fc950479b2a791cceae3d6fe3f32e573243b004d1f8e0a3df92211680",
+    "https://deno.land/std@0.118.0/fs/move.ts": "4623058e39bbbeb3ad30aeff9c974c55d2d574ad7c480295c12b04c244686a99",
+    "https://deno.land/std@0.118.0/fs/walk.ts": "31464d75099aa3fc7764212576a8772dfabb2692783e6eabb910f874a26eac54",
+    "https://deno.land/std@0.118.0/path/_constants.ts": "1247fee4a79b70c89f23499691ef169b41b6ccf01887a0abd131009c5581b853",
+    "https://deno.land/std@0.118.0/path/_interface.ts": "1fa73b02aaa24867e481a48492b44f2598cd9dfa513c7b34001437007d3642e4",
+    "https://deno.land/std@0.118.0/path/_util.ts": "2e06a3b9e79beaf62687196bd4b60a4c391d862cfa007a20fc3a39f778ba073b",
+    "https://deno.land/std@0.118.0/path/common.ts": "f41a38a0719a1e85aa11c6ba3bea5e37c15dd009d705bd8873f94c833568cbc4",
+    "https://deno.land/std@0.118.0/path/glob.ts": "ea87985765b977cc284b92771003b2070c440e0807c90e1eb0ff3e095911a820",
+    "https://deno.land/std@0.118.0/path/mod.ts": "4465dc494f271b02569edbb4a18d727063b5dbd6ed84283ff906260970a15d12",
+    "https://deno.land/std@0.118.0/path/posix.ts": "34349174b9cd121625a2810837a82dd8b986bbaaad5ade690d1de75bbb4555b2",
+    "https://deno.land/std@0.118.0/path/separator.ts": "8fdcf289b1b76fd726a508f57d3370ca029ae6976fcde5044007f062e643ff1c",
+    "https://deno.land/std@0.118.0/path/win32.ts": "11549e8c6df8307a8efcfa47ad7b2a75da743eac7d4c89c9723a944661c8bd2e"
+  },
   "workspace": {
     "dependencies": [
       "jsr:@404wolf/xdg-portable@0.1",

--- a/profile.ts
+++ b/profile.ts
@@ -1,0 +1,111 @@
+import { join } from "@std/path";
+import { randomValName } from "~/sdk.ts";
+
+const vtCmd = Deno.args[0] ? join(Deno.cwd(), Deno.args[0]) : "vt";
+const tempDir = await Deno.makeTempDir();
+
+try {
+  const n = 5;
+
+  await doProfileCase(
+    "vt remix",
+    tempDir,
+    [
+      "remix",
+      "https://www.val.town/x/wolf/VtStressTestProject",
+      randomValName(),
+      "--no-editor-files",
+    ],
+    false,
+    n,
+  );
+
+  await doProfileCase(
+    "vt status",
+    tempDir,
+    ["status"],
+    true,
+    n,
+  );
+
+  await doProfileCase(
+    "vt pull",
+    tempDir,
+    ["pull", "-f"],
+    true,
+    n,
+  );
+
+  for await (const dirEntry of Deno.readDir(tempDir)) {
+    if (dirEntry.isDirectory) {
+      const dirPath = join(tempDir, dirEntry.name);
+      const asciiContent = crypto.randomUUID().repeat(1000);
+      for (let j = 0; j < 50; j++) {
+        const filePath = join(dirPath, `file${j}-${crypto.randomUUID()}.txt`);
+        await Deno.writeTextFile(filePath, asciiContent);
+      }
+      console.log(`Created 50 files in ${dirPath}`);
+    }
+  }
+
+  await doProfileCase(
+    "vt push",
+    tempDir,
+    ["push"],
+    true,
+    n,
+  );
+} finally {
+  await Deno.remove(tempDir, { recursive: true });
+}
+
+/**
+ * Executes a profiling case with timing information.
+ *
+ * This function runs a command using the vt CLI and measures its execution time.
+ * It can either run a single command in the specified directory or iterate through
+ * subdirectories and run commands in each one.
+ *
+ * @param description - A description of the profiling case to be displayed
+ * @param tempDir - The directory path where the command(s) will be executed
+ * @param args - An array of command arguments
+ * @param iterateDirectories - If true, will execute the command in each subdirectory of tempDir
+ *                             If false (default), will execute the command in tempDir only
+ * @param n - Number of times to run the command (default is 1)
+ */
+async function doProfileCase(
+  description: string,
+  tempDir: string,
+  args: string[],
+  iterateDirectories: boolean = false,
+  n: number = 1,
+) {
+  console.log(`Profiling '${description}'`);
+  const start = performance.now();
+
+  for (let i = 0; i < n; i++) {
+    if (iterateDirectories) {
+      for await (const dirEntry of Deno.readDir(tempDir)) {
+        if (dirEntry.isDirectory) {
+          const dirPath = join(tempDir, dirEntry.name);
+          const command = new Deno.Command(vtCmd, {
+            args,
+            cwd: dirPath,
+          });
+          const {stdout} = await command.output();
+          console.log(new TextDecoder().decode(stdout));
+        }
+      }
+    } else {
+      const command = new Deno.Command(vtCmd, {
+        args,
+        cwd: tempDir,
+      });
+      await command.output();
+    }
+  }
+
+  const duration = performance.now() - start;
+  console.log(`Duration: ${duration.toFixed(4)} ms`);
+  console.log();
+}

--- a/profile.ts
+++ b/profile.ts
@@ -92,8 +92,7 @@ async function doProfileCase(
             args,
             cwd: dirPath,
           });
-          const {stdout} = await command.output();
-          console.log(new TextDecoder().decode(stdout));
+          await command.output();
         }
       }
     } else {

--- a/src/cmd/lib/pull.ts
+++ b/src/cmd/lib/pull.ts
@@ -48,7 +48,6 @@ export const pullCmd = new Command()
 
           // No need to confirm since they are just doing a dry run
           if (dryRun) return;
-          console.log();
 
           // Ask for confirmation to proceed despite dirty state
           const shouldProceed = await Confirm.prompt({

--- a/src/cmd/lib/push.ts
+++ b/src/cmd/lib/push.ts
@@ -29,7 +29,6 @@ export const pushCmd = new Command()
         const vtState = await vt.getMeta().loadVtState();
         const valToPush = await sdk.vals.retrieve(vtState.val.id);
         if (valToPush.author.id !== user.id) {
-          console.log(valToPush.author.id, user.id);
           throw new Error(
             "You are not the owner of this val, you cannot push." +
               "\nTo make a PR, go to the website, fork the Val, clone the fork, make changes, push them, and then PR on the website.",

--- a/src/cmd/lib/watch.ts
+++ b/src/cmd/lib/watch.ts
@@ -14,7 +14,7 @@ export const watchCmd = new Command()
   .option(
     "-d, --debounce-delay <delay:number>",
     "Debounce delay in milliseconds",
-    { default: 1500 },
+    { default: 250 },
   )
   .action(async (options) => {
     await doWithSpinner("Starting watch...", async (spinner) => {

--- a/src/cmd/tests/utils.ts
+++ b/src/cmd/tests/utils.ts
@@ -113,7 +113,7 @@ export async function runVtCommand(
         writer.write(new TextEncoder().encode("\b".repeat(10) + "yes\n"))
           .catch(() => {}); // Ignore errors when writing to stdin
         writer.releaseLock();
-      }, 100);
+      }, 50);
     }
 
     try {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -104,3 +104,6 @@ export const VAL_ITEM_NAME_REGEX = new RegExp("^[a-zA-Z0-9\\-_.]+$");
 export const MAX_FILENAME_LENGTH = 80;
 export const MAX_FILE_CHARS = 80_000;
 export const DEFAULT_EDITOR_TEMPLATE = "std/vtEditorFiles";
+
+export const AUTH_CACHE_TTL = 60 * 60 * 1000; // 1 hour
+export const AUTH_CACHE_LOCALSTORE_ENTRY = "vt_last_auth_cache";

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -132,6 +132,28 @@ export const getValItem = memoize(async (
 });
 
 /**
+ * Get the content of a Val item.
+ *
+ * @param {string} valId The ID of the Val
+ * @param {string} branchId The ID of the Val branch to reference
+ * @param {number} version The version of the Val
+ * @param {string} filePath The path to the file
+ * @returns {Promise<string>} Promise resolving to the file content
+ */
+export const getValItemContent = memoize(
+  async (
+    valId: string,
+    branchId: string,
+    version: number,
+    filePath: string,
+  ): Promise<string> => {
+    return await sdk.vals.files
+      .getContent(valId, { path: filePath, branch_id: branchId, version })
+      .then((resp) => resp.text());
+  },
+);
+
+/**
   * Lists all file paths in a Val with pagination support.
   *
   * @param {string} valId The ID of the val.

--- a/src/vt/lib/clone.ts
+++ b/src/vt/lib/clone.ts
@@ -171,7 +171,6 @@ async function createFile(
       remoteMtime: valMtime,
       localContent: localContent,
       localMtime: localMtime,
-      where: "remote",
     });
 
     if (modified) {

--- a/src/vt/lib/clone.ts
+++ b/src/vt/lib/clone.ts
@@ -167,10 +167,11 @@ async function createFile(
     );
 
     const modified = isFileModified({
-      srcContent: localContent,
-      srcMtime: localMtime,
-      dstContent: valContent,
-      dstMtime: valMtime,
+      remoteContent: valContent,
+      remoteMtime: valMtime,
+      localContent: localContent,
+      localMtime: localMtime,
+      where: "remote",
     });
 
     if (modified) {

--- a/src/vt/lib/clone.ts
+++ b/src/vt/lib/clone.ts
@@ -1,4 +1,4 @@
-import sdk, { listValItems } from "~/sdk.ts";
+import { getValItemContent, listValItems } from "~/sdk.ts";
 import { shouldIgnore } from "~/vt/lib/paths.ts";
 import { ensureDir, exists } from "@std/fs";
 import { dirname } from "@std/path/dirname";
@@ -114,7 +114,7 @@ async function createFile(
   targetRoot: string,
   valId: string,
   branchId: string,
-  version: number | undefined = undefined,
+  version: number,
   file: ValTown.Vals.FileRetrieveResponse,
   changes: ItemStatusManager,
   dryRun: boolean,
@@ -159,11 +159,12 @@ async function createFile(
 
     // Get its content for modification checking
     const localContent = await Deno.readTextFile(join(originalRoot, path));
-    const valContent = await sdk.vals.files.getContent(valId, {
-      path,
-      branch_id: branchId,
+    const valContent = await getValItemContent(
+      valId,
+      branchId,
       version,
-    }).then((resp) => resp.text());
+      path,
+    );
 
     const modified = isFileModified({
       srcContent: localContent,
@@ -205,10 +206,12 @@ async function createFile(
   if (fileStatus.status === "not_modified") {
     await Deno.copyFile(join(originalRoot, path), join(targetRoot, path));
   } else {
-    const content = await sdk.vals.files.getContent(
+    const content = await getValItemContent(
       valId,
-      { path: file.path, branch_id: branchId, version },
-    ).then((resp) => resp.text());
+      branchId,
+      version,
+      file.path,
+    );
 
     await Deno.writeTextFile(join(targetRoot, path), content);
   }

--- a/src/vt/lib/pull.ts
+++ b/src/vt/lib/pull.ts
@@ -99,7 +99,7 @@ export function pull(params: PullParams): Promise<PushResult> {
         const tmpDirPath = entry.path;
 
         if (shouldIgnore(relativePath, gitignoreRules)) continue;
-        if (relativePath === "" || entry.path === tmpDir) continue;
+        if (relativePath === "." || entry.path === tmpDir) continue;
         if (valItemsSet.has(relativePath)) continue;
 
         const stat = await Deno.stat(entry.path);

--- a/src/vt/lib/push.ts
+++ b/src/vt/lib/push.ts
@@ -54,7 +54,6 @@ export async function push(params: PushParams): Promise<PushResult> {
 
   assert(await exists(targetDir), "target directory doesn't exist");
 
-  // Retrieve the status
   const itemStateChanges = await status({
     targetDir,
     valId,
@@ -63,7 +62,7 @@ export async function push(params: PushParams): Promise<PushResult> {
     gitignoreRules,
   });
 
-  if (dryRun) return { itemStateChanges: itemStateChanges }; // Exit early if dry run
+  if (dryRun) return { itemStateChanges }; // Exit early if dry run
 
   // Create a filtered down status with everything that is safe to upload
   const safeItemStateChanges = new ItemStatusManager();

--- a/src/vt/lib/status.ts
+++ b/src/vt/lib/status.ts
@@ -1,4 +1,4 @@
-import sdk, { listValItems } from "~/sdk.ts";
+import { getValItemContent, listValItems } from "~/sdk.ts";
 import { getValItemType, shouldIgnore } from "~/vt/lib/paths.ts";
 import * as fs from "@std/fs";
 import * as path from "@std/path";
@@ -164,11 +164,7 @@ async function getValFiles({
         mtime: new Date(file.updatedAt).getTime(),
         content: file.type === "directory"
           ? undefined
-          : await sdk.vals.files.getContent(valId, {
-            path: file.path,
-            branch_id: branchId,
-            version,
-          }).then((resp) => resp.text()),
+          : await getValItemContent(valId, branchId, version, file.path),
       })),
   );
 }

--- a/src/vt/lib/status.ts
+++ b/src/vt/lib/status.ts
@@ -85,10 +85,11 @@ export async function status(params: StatusParams): Promise<ItemStatusManager> {
         const localStat = await Deno.stat(path.join(targetDir, localFile.path));
         // File exists in both places, check if modified
         const isModified = isFileModified({
-          srcContent: localFile.content!, // We know it isn't a dir, so there should be content
-          srcMtime: localFile.mtime,
-          dstContent: valFileInfo.content!,
-          dstMtime: valFileInfo.mtime,
+          localContent: localFile.content!, // We know it isn't a dir, so there should be content
+          localMtime: localFile.mtime,
+          remoteContent: valFileInfo.content!,
+          remoteMtime: valFileInfo.mtime,
+          where: "both",
         });
 
         if (isModified) {

--- a/src/vt/lib/tests/push_test.ts
+++ b/src/vt/lib/tests/push_test.ts
@@ -1,5 +1,10 @@
 import { doWithNewVal } from "~/vt/lib/tests/utils.ts";
-import sdk, { getLatestVersion, listValItems, valItemExists } from "~/sdk.ts";
+import sdk, {
+  getLatestVersion,
+  getValItemContent,
+  listValItems,
+  valItemExists,
+} from "~/sdk.ts";
 import { push } from "~/vt/lib/push.ts";
 import { assert, assertEquals } from "@std/assert";
 import { join } from "@std/path";
@@ -270,12 +275,13 @@ Deno.test({
           });
 
           // Pull and assert that the creation worked
-          const originalFileContent = await sdk.vals.files
-            .getContent(val.id, {
-              path: vtFilePath,
-              branch_id: branch.id,
-            })
-            .then((resp) => resp.text());
+          const originalFileContent = await getValItemContent(
+            val.id,
+            branch.id,
+            await getLatestVersion(val.id, branch.id),
+            vtFilePath,
+          );
+
           assertEquals(
             originalFileContent,
             "test",
@@ -291,12 +297,13 @@ Deno.test({
           });
 
           // Pull and assert that the modification worked
-          const newFileContent = await sdk.vals.files
-            .getContent(val.id, {
-              path: vtFilePath,
-              branch_id: branch.id,
-            })
-            .then((resp) => resp.text());
+          const newFileContent = await getValItemContent(
+            val.id,
+            branch.id,
+            await getLatestVersion(val.id, branch.id),
+            vtFilePath,
+          );
+
           assertEquals(newFileContent, "test2");
         });
 
@@ -455,12 +462,13 @@ Deno.test({
           assertEquals(renamedFile.type, "http");
 
           // Verify content is preserved
-          const content = await sdk.vals.files
-            .getContent(val.id, {
-              path: "val/new.tsx",
-              branch_id: branch.id,
-            })
-            .then((resp) => resp.text());
+          const content = await getValItemContent(
+            val.id,
+            branch.id,
+            await getLatestVersion(val.id, branch.id),
+            "val/new.tsx",
+          );
+
           assertEquals(content, "contentt");
         });
 
@@ -778,26 +786,28 @@ Deno.test({
 
         await t.step("verify server state after push", async () => {
           // Check content on the server to verify the push succeeded
-          const writableContent = await sdk.vals.files
-            .getContent(val.id, {
-              path: "writable.txt",
-              branch_id: branch.id,
-            })
-            .then((resp) => resp.text());
+          const latestVersion = await getLatestVersion(val.id, branch.id);
 
-          const readOnlyContent = await sdk.vals.files
-            .getContent(val.id, {
-              path: "readonly.txt",
-              branch_id: branch.id,
-            })
-            .then((resp) => resp.text());
+          const writableContent = await getValItemContent(
+            val.id,
+            branch.id,
+            latestVersion,
+            "writable.txt",
+          );
 
-          const anotherContent = await sdk.vals.files
-            .getContent(val.id, {
-              path: "another.txt",
-              branch_id: branch.id,
-            })
-            .then((resp) => resp.text());
+          const readOnlyContent = await getValItemContent(
+            val.id,
+            branch.id,
+            latestVersion,
+            "readonly.txt",
+          );
+
+          const anotherContent = await getValItemContent(
+            val.id,
+            branch.id,
+            latestVersion,
+            "another.txt",
+          );
 
           // Verify the content matches what we expect
           assertEquals(

--- a/src/vt/lib/utils/misc.ts
+++ b/src/vt/lib/utils/misc.ts
@@ -79,20 +79,13 @@ export function isFileModified({
   localMtime,
   remoteContent,
   remoteMtime,
-  where,
 }: {
   localContent: string;
   localMtime: number;
   remoteContent: string;
   remoteMtime: number;
-  where: "local" | "remote" | "both";
 }): boolean {
-  // If the local mtime is not newer than the remote mtime, it hasn't changed
-  if (where === "local" && localMtime <= remoteMtime) return false;
-  // Likewise, if the remote mtime is not newer than the local mtime, it hasn't changed
-  if (where === "remote" && remoteMtime <= localMtime) return false;
-  // If both mtime are the same, no need to check content
-  if (where === "both" && localMtime === remoteMtime) return false; 
+  if (localMtime === remoteMtime) return false;
 
   // If mtime indicates a possible change, check content
   return localContent !== remoteContent;

--- a/src/vt/lib/utils/misc.ts
+++ b/src/vt/lib/utils/misc.ts
@@ -75,21 +75,27 @@ export async function doAtomically<T>(
  * @returns {boolean} True if the file has been modified, false otherwise
  */
 export function isFileModified({
-  srcContent,
-  srcMtime,
-  dstContent,
-  dstMtime,
+  localContent,
+  localMtime,
+  remoteContent,
+  remoteMtime,
+  where,
 }: {
-  srcContent: string;
-  srcMtime: number;
-  dstContent: string;
-  dstMtime: number;
+  localContent: string;
+  localMtime: number;
+  remoteContent: string;
+  remoteMtime: number;
+  where: "local" | "remote" | "both";
 }): boolean {
-  // First use the mtime as a heuristic to avoid unnecessary content checks
-  if (srcMtime === dstMtime) return false;
+  // If the local mtime is not newer than the remote mtime, it hasn't changed
+  if (where === "local" && localMtime <= remoteMtime) return false;
+  // Likewise, if the remote mtime is not newer than the local mtime, it hasn't changed
+  if (where === "remote" && remoteMtime <= localMtime) return false;
+  // If both mtime are the same, no need to check content
+  if (where === "both" && localMtime === remoteMtime) return false; 
 
   // If mtime indicates a possible change, check content
-  return srcContent !== dstContent;
+  return localContent !== remoteContent;
 }
 
 /**

--- a/vt.ts
+++ b/vt.ts
@@ -72,9 +72,9 @@ async function ensureValidApiKey() {
   }
 }
 
-async function startVt() {
+async function startVt(...args: string[]) {
   const vt = (await import("~/cmd/root.ts")).cmd;
-  await vt.parse(Deno.args);
+  await vt.parse([...Deno.args, ...args]);
 }
 
 if (import.meta.main) {

--- a/vt.ts
+++ b/vt.ts
@@ -2,18 +2,37 @@
 import "@std/dotenv/load";
 import { ensureGlobalVtConfig, globalConfig } from "~/vt/VTConfig.ts";
 import { onboardFlow } from "~/cmd/flows/onboard.ts";
-import { API_KEY_KEY } from "~/consts.ts";
+import {
+  API_KEY_KEY,
+  AUTH_CACHE_LOCALSTORE_ENTRY,
+  AUTH_CACHE_TTL,
+} from "~/consts.ts";
 import { colors } from "@cliffy/ansi/colors";
 
 await ensureGlobalVtConfig();
 
 async function isApiKeyValid(): Promise<boolean> {
+  // Since we run this on every invocation of vt, it makes sense to only check
+  // if the api key is still valid every so often.
+
+  const lastAuthAt = localStorage.getItem(AUTH_CACHE_LOCALSTORE_ENTRY);
+  const hoursSinceLastAuth = lastAuthAt
+    ? (new Date().getTime() - new Date(lastAuthAt).getTime())
+    : Infinity;
+  if (hoursSinceLastAuth < AUTH_CACHE_TTL) return true;
+
   const apiKey = Deno.env.get(API_KEY_KEY);
   if (!apiKey) return false;
 
   const resp = await fetch("https://api.val.town/v1/me", {
     headers: { Authorization: `Bearer ${apiKey}` },
   });
+
+  if (resp.ok) {
+    localStorage.setItem(AUTH_CACHE_LOCALSTORE_ENTRY, new Date().toISOString());
+    return true;
+  }
+
   return resp.status !== 401;
 }
 
@@ -33,7 +52,7 @@ async function ensureValidApiKey() {
           " This happens when it expires or is revoked.",
       );
       console.log();
-      await onboardFlow({ showWelcome: false });
+      await onboardFlow();
     } else {
       console.log("Let's set up your Val Town API key.");
       await onboardFlow();


### PR DESCRIPTION
TLDR: many performance updates. Pushing is now about 40% faster.

- Move CI for command line stuff to linux, since github Mac CI is too spotty and slow
- `vt watch` will only consider changes since the last push instead of pushing everything, by injecting all files except the ones since the last push into the gitignore list.
- Memoize file retrieval
- `vt status` now will get remote val files from the local file system if the local utime is the exact same as val town's. Having the same utime is a heuristic that the files haven't changed, and fetching content locally is much faster. This saves a ton of API calls!
- Add a basic profile script
- Only check to see if API key is valid (to exit early) on the first run in a while, then cache that so that vt is snappier if it was just validated (originally from https://github.com/val-town/vt/pull/120)