### PR TITLE
Fix issue with Renaming Files from Root to Root

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/src/vt/lib/push.ts
+++ b/src/vt/lib/push.ts
@@ -126,7 +126,8 @@ export async function push(params: PushParams): Promise<PushResult> {
           dirname(f.path),
         );
 
-        // If moving from a folder to the root
+        // If moving from a folder to the root, we have to do it as two API
+        // calls because of an API bug
         if (f.oldPath != basename(f.oldPath) && f.path === basename(f.path)) {
           promises.push(sdk.vals.files.update(valId, {
             branch_id: branchId,

--- a/src/vt/lib/tests/push_test.ts
+++ b/src/vt/lib/tests/push_test.ts
@@ -6,6 +6,63 @@ import { join } from "@std/path";
 import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 
 Deno.test({
+  name: "test renaming file at root",
+  permissions: "inherit",
+  async fn() {
+    await doWithNewVal(async ({ val, branch }) => {
+      await doWithTempDir(async (tempDir) => {
+        const oldFilePath = join(tempDir, "rootFile.txt");
+
+        // Create and push the original file
+        await Deno.writeTextFile(oldFilePath, "root file content");
+        await push({
+          targetDir: tempDir,
+          valId: val.id,
+          branchId: branch.id,
+        });
+
+        // Rename the file at the root
+        const newFilePath = join(tempDir, "renamedRootFile.txt");
+        await Deno.rename(oldFilePath, newFilePath);
+
+        // Push the renamed file
+        const { itemStateChanges: result } = await push({
+          targetDir: tempDir,
+          valId: val.id,
+          branchId: branch.id,
+        });
+
+        // Verify rename was detected
+        assertEquals(result.renamed.length, 1);
+        assertEquals(result.renamed[0].oldPath, "rootFile.txt");
+        assertEquals(result.renamed[0].path, "renamedRootFile.txt");
+
+        // If this doesn't throw it means it exists
+        assert(
+          await valItemExists(
+            val.id,
+            branch.id,
+            "renamedRootFile.txt",
+            await getLatestVersion(val.id, branch.id),
+          ),
+          "file should exist at new location",
+        );
+
+        assert(
+          !await valItemExists(
+            val.id,
+            branch.id,
+            "rootFile.txt",
+            await getLatestVersion(val.id, branch.id),
+          ),
+          "file should not exist at old location",
+        );
+      });
+    });
+  },
+});
+
+Deno.test({
   name: "test moving file from subdirectory to root",
   permissions: "inherit",
   async fn(t) {


### PR DESCRIPTION
Fix a bug where renaming a file at the root doesn't work. There's a surrounding API bug so this is likely a temporary fix.