### PR TITLE
Fix Critical API Key Access Error

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -24,6 +24,11 @@ export function getClonePath(
  */
 export function sanitizeErrors(error: unknown): string {
   if (error instanceof ValTown.APIError) {
+    if (error.status === 404) {
+      return "Resource not found. Please check the Val name or ID. " +
+        "You may not own this resource.";
+    }
+
     // Remove leading numbers from error message and convert to sentence case
     const cleanedMessage = error.message.replace(/^\d+\s+/, "");
     return cleanedMessage.charAt(0).toUpperCase() + cleanedMessage.slice(1);

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,8 +1,9 @@
 import ValTown from "@valtown/sdk";
 import { memoize } from "@std/cache";
-import { API_KEY_KEY, DEFAULT_BRANCH_NAME } from "~/consts.ts";
+import { DEFAULT_BRANCH_NAME } from "~/consts.ts";
 
-const sdk = new ValTown({ bearerToken: Deno.env.get(API_KEY_KEY)! });
+// Must get set in vt.ts entrypoint!
+const sdk = new ValTown({ bearerToken: crypto.randomUUID() });
 
 /**
  * Checks if a Val exists.

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,9 +1,12 @@
 import ValTown from "@valtown/sdk";
 import { memoize } from "@std/cache";
-import { DEFAULT_BRANCH_NAME } from "~/consts.ts";
+import { API_KEY_KEY, DEFAULT_BRANCH_NAME } from "~/consts.ts";
 
-// Must get set in vt.ts entrypoint!
-const sdk = new ValTown({ bearerToken: crypto.randomUUID() });
+const sdk = new ValTown({
+  // Must get set in vt.ts entrypoint if not set as an env var!
+  // It needs to be passed here though as *something*
+  bearerToken: Deno.env.get(API_KEY_KEY) ?? crypto.randomUUID(),
+});
 
 /**
  * Checks if a Val exists.

--- a/src/vt/VTConfig.ts
+++ b/src/vt/VTConfig.ts
@@ -176,7 +176,10 @@ export async function ensureGlobalVtConfig(): Promise<void> {
     // automatically (the config file didn't previously exist so we shouldn't
     // be overwriting anything)
     if (Deno.env.has(API_KEY_KEY)) {
-      startingConfig.apiKey = Deno.env.get(API_KEY_KEY)!; // (!, we just checked)
+      const apiKey = Deno.env.get(API_KEY_KEY)!; // (!, we just checked)
+      if (apiKey.length == 32 || apiKey.length == 33) {
+        startingConfig.apiKey = apiKey;
+      } else startingConfig.apiKey = "0".repeat(32);
     }
 
     await Deno.writeTextFile(

--- a/vt.ts
+++ b/vt.ts
@@ -37,7 +37,8 @@ async function ensureValidApiKey() {
       await onboardFlow({ showWelcome: false });
     } else {
       console.log("Let's set up your Val Town API key.");
-      await onboardFlow();
+      console.log();
+      await onboardFlow({ showWelcome: true });
     }
   }
 
@@ -59,7 +60,7 @@ async function startVt() {
 
 if (import.meta.main) {
   await ensureValidApiKey();
-  sdk.bearerToken = Deno.env.get(API_KEY_KEY)!;
+  sdk.bearerToken = Deno.env.get(API_KEY_KEY) ?? sdk.bearerToken;
   await startVt();
 }
 

--- a/vt.ts
+++ b/vt.ts
@@ -4,6 +4,7 @@ import { ensureGlobalVtConfig, globalConfig } from "~/vt/VTConfig.ts";
 import { onboardFlow } from "~/cmd/flows/onboard.ts";
 import { API_KEY_KEY } from "~/consts.ts";
 import { colors } from "@cliffy/ansi/colors";
+import sdk from "~/sdk.ts";
 
 await ensureGlobalVtConfig();
 
@@ -58,6 +59,7 @@ async function startVt() {
 
 if (import.meta.main) {
   await ensureValidApiKey();
+  sdk.bearerToken = Deno.env.get(API_KEY_KEY)!;
   await startVt();
 }
 


### PR DESCRIPTION
Fix a bug where we try to load `sdk.ts` and get an instant error that exits early saying "API key not set" since we are in the process of loading it. 

Right now we export `const sdk` directly from `sdk.ts`. This breaks when the env var is not set. I changed it to use `crypto.randomUUID()` as a fallback, since we *always* set it properly in `vt.ts` (the entrypoint). There's probably a more elegant way to do this.

**This is a temporary fix that will be improved later, but I'm merging since the current state is broken and won't load the API key from the system yaml properly.** I'll add testing soon for this as well.