### PR TITLE
Fix API login messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ To authenticate with `val.town`, just run `vt`, and you should get the dialog
 ```
 Welcome to the Val Town CLI!
 
-  VT is a companion CLI to interface with Val Town vals.
+  VT is a companion CLI to interface with Val Town Vals.
 
   With this CLI, you can:
-  - Create and manage Val Town vals
+  - Create and manage Val Town Vals
   - Push and pull changes between your local system and Val Town
   - Watch a directory to keep it automatically synced with Val Town
   - And more!

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/src/cmd/flows/onboard.ts
+++ b/src/cmd/flows/onboard.ts
@@ -22,7 +22,7 @@ function welcomeToVt(): void {
 
   console.log(wrap(
     colors.bold("VT") +
-      " is a companion CLI to interface with Val Town vals.",
+      " is a companion CLI to interface with Val Town Vals.",
     { width: DEFAULT_WRAP_WIDTH },
   ));
   console.log();
@@ -30,7 +30,7 @@ function welcomeToVt(): void {
   console.log(wrap("With this CLI, you can:", { width: DEFAULT_WRAP_WIDTH }));
 
   [
-    "Create and manage Val Town vals",
+    "Create and manage Val Town Vals",
     "Push and pull changes between your local system and Val Town",
     "Watch a directory to keep it automatically synced with Val Town",
     "And more!",

--- a/vt.ts
+++ b/vt.ts
@@ -36,8 +36,6 @@ async function ensureValidApiKey() {
       console.log();
       await onboardFlow({ showWelcome: false });
     } else {
-      console.log("Let's set up your Val Town API key.");
-      console.log();
       await onboardFlow({ showWelcome: true });
     }
   }


### PR DESCRIPTION
Remove the duplicate "Let's get your val town api key set up" message

![cd6ff078-d828-444e-9f10-5d77bf64528e](https://github.com/user-attachments/assets/f3d10330-43c0-4aba-b700-1ef046b74b29)
