### PR TITLE
Allow config retreival from anywhere

### DIFF
--- a/src/cmd/lib/config.ts
+++ b/src/cmd/lib/config.ts
@@ -53,10 +53,7 @@ export const configSetCmd = new Command()
     async ({ global }: { global?: boolean }, key: string, value: string) => {
       await doWithSpinner("Updating configuration...", async (spinner) => {
         // Check if we're in a Val Town Val directory
-        const vtRoot = await findVtRoot(Deno.cwd()).catch((e) => {
-          if (e instanceof Deno.errors.NotFound) return undefined;
-          else throw e;
-        });
+        const vtRoot = await findVtRoot(Deno.cwd()).catch(() => undefined);
 
         const useGlobal = global || !vtRoot;
         const vtConfig = new VTConfig(vtRoot);
@@ -116,10 +113,7 @@ export const configGetCmd = new Command()
   .action(async (_: unknown, key?: string) => {
     await doWithSpinner("Retreiving configuration...", async (spinner) => {
       // Check if we're in a Val Town Val directory
-      const vtRoot = await findVtRoot(Deno.cwd()).catch((e) => {
-        if (e instanceof Deno.errors.NotFound) return undefined;
-        else throw e;
-      });
+      const vtRoot = await findVtRoot(Deno.cwd()).catch(() => undefined);
 
       // Create config instance with the appropriate path
       const config = new VTConfig(vtRoot);

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -27,6 +27,7 @@ export function getClonePath(
 export function sanitizeErrors(error: unknown): string {
   if (error instanceof ValTown.APIError) {
     let suffixedExtra = "";
+
     if (error.status === 404) {
       if (error.message.toLowerCase().includes("branch")) {
         suffixedExtra = "You may have deleted the current branch. " +
@@ -38,6 +39,14 @@ export function sanitizeErrors(error: unknown): string {
           "This folder is no longer usable with `vt`. " +
           "If you have important files, create a new Val and copy them over.";
       }
+    } else if (error.status === 401) {
+      suffixedExtra =
+        "You may need to re-authenticate. To set a new API key, use `vt config set apiKey new_api_key`";
+    }
+
+    if (error.message.includes("required permissions")) {
+      suffixedExtra +=
+        "To set a new API key, use `vt config set apiKey new_api_key`";
     }
 
     // Remove leading numbers from error message


### PR DESCRIPTION
Instead of
![cdc2c1f2-9726-457a-b087-e27778b28c29](https://github.com/user-attachments/assets/f8383d26-0ee9-41d3-ba85-40e6be39e8ec)

When you use `vt config get`

Show the user

![e5b05d46-02d6-4afb-99de-30729b153e0c](https://github.com/user-attachments/assets/ff59451f-42ed-4f0e-a1fb-1aada34e49cd)

Which is their global config.

Also, suggest how to update the env var if theirs doesn't work:
![41db6f08-80cc-4f0b-82d9-f4eebfcbb823](https://github.com/user-attachments/assets/8ba07aec-ba5e-4696-9f1b-8c1be88d0255)
![07a97b09-0842-428e-8aa2-f36f1f315c2e](https://github.com/user-attachments/assets/ab653a0d-ac31-4331-ad37-8f627f1fc0fc)
