### PR TITLE
Add shell completions command

### DIFF
--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -1,4 +1,5 @@
 import { Command } from "@cliffy/command";
+import { CompletionsCommand } from "@cliffy/command/completions";
 import manifest from "../../deno.json" with { type: "json" };
 import * as cmds from "~/cmd/lib/mod.ts";
 import { upgradeCmd } from "./upgrade.ts";
@@ -25,5 +26,7 @@ cmd.command("config", cmds.configCmd);
 cmd.command("delete", cmds.deleteCmd);
 cmd.command("list", cmds.listCmd);
 cmd.command("tail", cmds.tailCmd);
+cmd.command("completions", new CompletionsCommand());
+
 
 export { cmd };


### PR DESCRIPTION
This PR adds shell completion support to the CLI by introducing a new `completions` command using the `@cliffy/command/completions` package. This will make it easier for users to set up shell autocompletion for the CLI.

**New CLI feature:**

* Added the `completions` command to the CLI by importing and registering `CompletionsCommand` from `@cliffy/command/completions` in `src/cmd/root.ts`.