### PR TITLE
Fix device auth token refresh crash on expired refresh tokens

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/vt.ts
+++ b/vt.ts
@@ -51,23 +51,19 @@ async function ensureValidApiKey() {
       if (await isApiKeyValid()) return;
 
       // Attempt to refresh if there is a refresh token
-      try {
-        if (refreshToken) {
+      if (refreshToken) {
+        try {
           const newTokens = await refreshTokens(refreshToken);
           globalConfig.saveGlobalConfig({
             apiKey: newTokens.access_token,
             refreshToken: newTokens.refresh_token,
           });
           Deno.env.set(API_KEY_KEY, newTokens.access_token);
-          if (!await isApiKeyValid()) {
-            throw Error("Refreshed API key is invalid");
-          }
+          if (await isApiKeyValid()) return;
+        } catch {
+          // Refresh failed (expired/revoked refresh token, network error, etc.)
+          // Fall through to re-login
         }
-      } catch (e: unknown) {
-        if (Error.isError(e) && e.message !== "Refreshed API key is invalid") {
-          throw e;
-        }
-        // We'll make them get a new one
       }
 
       console.log(

--- a/vt.ts
+++ b/vt.ts
@@ -54,7 +54,7 @@ async function ensureValidApiKey() {
       if (refreshToken) {
         try {
           const newTokens = await refreshTokens(refreshToken);
-          globalConfig.saveGlobalConfig({
+          await globalConfig.saveGlobalConfig({
             apiKey: newTokens.access_token,
             refreshToken: newTokens.refresh_token,
           });


### PR DESCRIPTION
## Summary
- When `refreshTokens()` threw (e.g., expired/revoked refresh token or network error), the catch block re-threw the error instead of falling through to the re-login flow, crashing the CLI
- Now all refresh failures are caught and the user is gracefully prompted to log in again

## Test plan
- [x] Run `vt` with an expired access token and valid refresh token — should silently refresh
- [x] Run `vt` with an expired access token and expired/revoked refresh token — should show "API key is no longer valid" and prompt re-login (instead of crashing)
- [x] Run `vt` with no refresh token — should prompt re-login as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)