### PR TITLE
Ignore .git by Default When Syncing

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -19,7 +19,12 @@ export const VAL_TOWN_OAUTH_API_URL = IS_LOCAL_ENV
 export const OAUTH_SCOPES =
   "openid offline_access project_rw user_r telemetry_r";
 
-export const ALWAYS_IGNORE_PATTERNS: string[] = [".vt", ".env", "node_modules"];
+export const ALWAYS_IGNORE_PATTERNS: string[] = [
+  ".vt",
+  ".git",
+  ".env",
+  "node_modules",
+];
 
 export const DEFAULT_IGNORE_PATTERNS: string[] = ["*~", "*.swp", ".env"];
 

--- a/src/vt/lib/paths.ts
+++ b/src/vt/lib/paths.ts
@@ -96,5 +96,7 @@ export function shouldIgnore(
   // All the libraries for this kinda suck, but this mostly works. Note that
   // there might still be bugs in the gitignore logic.
   const gitignore = compileGitignore(gitignoreRules.join("\n"));
-  return gitignore.denies(pathToCheck);
+  // Also check with a trailing slash so that directory-only patterns (like
+  // ".github/") match directory paths, which are walked without one.
+  return gitignore.denies(pathToCheck) || gitignore.denies(pathToCheck + "/");
 }


### PR DESCRIPTION
## Problem

Running `vt push` in a directory that is also a git working copy uploads the entire `.git` directory into the val. Observed live today with vt 0.1.54: a push with no `.vtignore` created 51 files/directories under `.git/` in the val, and the binary object/pack files failed with "File has binary content". Anyone syncing a val with a git repo hits this immediately.

vt already always-ignores its own `.vt` state dir (plus `.env` and `node_modules`) via `ALWAYS_IGNORE_PATTERNS`, but `.git` was missing from that list.

## Evidence

`vt push --dry-run` in a fresh val directory after `git init` + one commit, before the fix:

```
  A (file     ) .git/hooks/post-update.sample
  ... (whole .git tree) ...
  A (directory) .git
  A (file     ) readme.md

Failures:
  A (file     ) .git/index
        Error: File has binary content
  ... (4 more binary object files) ...

Would push:
  43 created
  5 failed
```

## Fix

- Add `".git"` to `ALWAYS_IGNORE_PATTERNS` in `src/consts.ts`, so `.git` is excluded from push/pull/status/watch/checkout the same way `.vt` already is. `.vtignore` files still layer on top as before.
- While in the same matching logic, fix an adjacent observed bug: a `.vtignore` pattern with a trailing slash (e.g. `.github/`) ignored the directory's contents but not the directory entry itself (directories are walked without a trailing slash), so `vt push` still created an empty `.github` directory in the val. `shouldIgnore` now also checks the path with a trailing slash appended, so directory-only patterns match.

## Verification

Reproduced end to end against the live API with a throwaway val (since deleted), running vt from this checkout:

- Before: `push --dry-run` listed the whole `.git` tree (43 created, 5 binary failures) and created an empty `.github` directory despite `.github/` in `.vtignore`.
- After: `push --dry-run` and a real push uploaded only `.vtignore` and `readme.md`; the val's file listing confirmed no `.git` or `.github` entries.
- Unit-checked `shouldIgnore` directly: `.git`, `.git/config`, `.git/objects/pack/x.pack` denied by the new default; `.github` and `.github/workflows/ci.yml` denied by a `.github/` pattern; `readme.md`, `src/main.ts`, `other` still allowed. Negated patterns (`!keep.log`, `!build/keep.txt`) still behave the same with the trailing-slash check.
- `deno task fmt:check` passes. `deno task check` and the test suite fail identically on unmodified main with Deno 2.8.2 (pre-existing `Timeout` type error in `src/cmd/tests/utils.ts` and a `@valtown/sdk` `Headers` import that breaks under `verbatimModuleSyntax`); CI on main has also been red on the test step since before this change.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
