### PR TITLE
Exit With a Helpful Error Instead of Hanging When the Org Picker Cannot Prompt

### DIFF
--- a/src/cmd/lib/create.ts
+++ b/src/cmd/lib/create.ts
@@ -89,6 +89,12 @@ vt checkout main`,
         const orgNames = orgs.map((o) => o.username!);
         const orgIds = orgs.map((o) => o.id!);
         if (orgNames.length > 0) {
+          if (!Deno.stdin.isTerminal()) {
+            throw new Error(
+              "You are a member of organizations, but the account picker requires an interactive terminal.\n" +
+                'Pass --org-name to choose an organization, or --org-name "me" for your personal account.',
+            );
+          }
           spinner.stop();
           const orgOrMe = await Select.prompt({
             search: true,

--- a/src/cmd/tests/create_test.ts
+++ b/src/cmd/tests/create_test.ts
@@ -298,7 +298,7 @@ Deno.test({
 });
 
 Deno.test({
-  name: "Get prompted for org to create Val in",
+  name: "Get told to use --org-name when stdin is not interactive",
   permissions: "inherit",
   async fn(t) {
     await doWithTempDir(async (tmpDir) => {
@@ -309,12 +309,14 @@ Deno.test({
           tmpDir,
         );
 
-        for (let i = 0; i < 100; i++) { // wait a bit to get prompt data
-          if (stdout.join("\n").includes("organization you are a")) return;
+        for (let i = 0; i < 100; i++) { // wait a bit to get the error
+          if (stdout.join("\n").includes("--org-name")) return;
           await delay(50);
         }
 
-        throw new AssertionError("Was never prompted for org to create Val in");
+        throw new AssertionError(
+          "Was never told to use --org-name to choose an account",
+        );
       });
     });
   },

--- a/src/cmd/tests/utils.ts
+++ b/src/cmd/tests/utils.ts
@@ -69,7 +69,7 @@ export async function runVtCommand(
     });
 
     // If autoConfirm is enabled, send "yes\n" repeatedly to stdin
-    let autoConfirmInterval: number | undefined;
+    let autoConfirmInterval: ReturnType<typeof setInterval> | undefined;
 
     const cleanup = () => {
       if (autoConfirmInterval) {


### PR DESCRIPTION
## Problem

When the logged-in account belongs to organizations, `vt create` shows an interactive picker asking whether to create the Val under an org or the personal account. If stdin is not a terminal — scripts, CI, `vt create my-val </dev/null` — the picker cannot receive input, so the command spins forever. Nothing tells the user that `--org-name` (or `--org-name me` for the personal account) would skip the prompt.

## Evidence

Reproduced on main (vt 0.1.54 behavior) with an account that belongs to orgs:

```
$ vt create test-val-hang-xyz </dev/null
⠹ Creating new Val...
? Would you like to create the new Val under an organization you are a member of, or your personal account? ...
# still running after 20s, never exits
```

## Fix

In the `vt create` action, before showing the picker, check `Deno.stdin.isTerminal()`. When stdin is not a terminal, throw instead of prompting; the existing error handling prints the message and exits 1:

```
X You are a member of organizations, but the account picker requires an interactive terminal.
Pass --org-name to choose an organization, or --org-name "me" for your personal account.
```

The existing test "Get prompted for org to create Val in" asserted the old behavior (the picker rendering to a piped subprocess), so it is updated to assert the new error message instead.

## Verification

- Before: `vt create test-val-hang-xyz </dev/null` hangs indefinitely (killed after 20s). After: exits 1 immediately with the message above.
- Verified the picker still appears when stdin is a real terminal (ran under a pty via `script`).
- `./src/cmd/tests/create_test.ts`: 6 passed (12 steps), 0 failed, including the updated prompt test.
- `deno task fmt:check` passes; `deno check src/cmd/lib/create.ts` passes.

Note: a parallel PR for a different vt bug may introduce a similar stdin-TTY check; this one is kept local to `vt create` on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/vt/pull/260" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->