### PR TITLE
Fail Fast Instead of Looping Forever When Login Is Needed and Stdin Is Not Interactive

### DIFF
--- a/src/cmd/flows/onboard.ts
+++ b/src/cmd/flows/onboard.ts
@@ -1,6 +1,7 @@
 import { Confirm } from "@cliffy/prompt";
 import { colors } from "@cliffy/ansi/colors";
 import {
+  API_KEY_KEY,
   DEFAULT_WRAP_WIDTH,
   GET_API_KEY_URL,
   GLOBAL_VT_CONFIG_PATH,
@@ -52,6 +53,16 @@ export async function onboardFlow(
   options?: { showWelcome?: boolean },
 ): Promise<void> {
   options = options || {};
+
+  if (!Deno.stdin.isTerminal()) {
+    console.error(
+      colors.red("Authentication required, but stdin is not interactive."),
+    );
+    console.error(
+      `Set the ${API_KEY_KEY} environment variable to an API key from ${GET_API_KEY_URL}`,
+    );
+    Deno.exit(1);
+  }
 
   if (options.showWelcome) {
     welcomeToVt();


### PR DESCRIPTION
## Problem

When `vt` needs authentication (no/empty/invalid `VAL_TOWN_API_KEY`) in a non-interactive environment — CI, scripts, anything with stdin closed or piped — it prints the "We can log you in automatically! Would you like to proceed to vt's login page in your browser?" prompt in an infinite busy-loop at ~99% CPU. In GitHub Actions this is a silent hang until the 6-hour job timeout, with the prompt repeated millions of times in the logs.

## Evidence

Repro against `main` (fresh config dir, closed stdin):

```
VAL_TOWN_API_KEY="" vt clone someval /tmp/x </dev/null
```

Observed: 17,480 repetitions of the login prompt and 3.2 MB of output in 8 seconds at ~97% CPU before being killed. The cliffy `Confirm` prompt's internal read loop gets EOF, treats it as no input, and re-renders forever — and `onboardFlow` calls it unconditionally.

## Fix

At the start of `onboardFlow`, if `Deno.stdin.isTerminal()` is false, print a clear error telling the user to set `VAL_TOWN_API_KEY` and exit with code 1 instead of prompting.

After the fix, the same repro exits immediately:

```
Authentication required, but stdin is not interactive.
Set the VAL_TOWN_API_KEY environment variable to an API key from https://www.val.town/settings/api
```

with exit code 1.

## Verification

- Repro above: before = infinite loop; after = immediate exit 1 with the message.
- Interactive path unchanged: ran the same command under a pty (`script`), the confirm prompt renders once, answering `n` prints the manual API-key instructions as before.
- `deno fmt --check` passes. `deno task check` / `deno task test` fail on current `main` before this change (pre-existing `TS2322` in `src/cmd/tests/utils.ts` under recent Deno; the "VT Testing" workflow is already red on `main`); `deno check src/cmd/flows/onboard.ts` passes.

Note: a sibling PR fixing a different non-interactive bug may add a similar stdin-TTY check elsewhere; this one is kept local to the auth entry point on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/vt/pull/261" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->