### PR TITLE
Exit Non-Zero When Push Fails to Upload Some Files

### DIFF
--- a/src/cmd/lib/push.ts
+++ b/src/cmd/lib/push.ts
@@ -65,6 +65,7 @@ export const pushCmd = new Command()
           console.log();
           if (statusResult.hasWarnings()) {
             spinner.warn("Failed to push everything");
+            Deno.exit(1);
           } else {
             spinner.succeed("Successfully pushed local changes");
           }

--- a/src/cmd/tests/push_test.ts
+++ b/src/cmd/tests/push_test.ts
@@ -2,7 +2,7 @@ import { doWithNewVal } from "~/vt/lib/tests/utils.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
 import { runVtCommand } from "~/cmd/tests/utils.ts";
-import { assertStringIncludes } from "@std/assert";
+import { assertEquals, assertStringIncludes } from "@std/assert";
 import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 
 Deno.test({
@@ -174,12 +174,13 @@ Deno.test({
 
         await t.step("try to push binary file and verify failure", async () => {
           // Run push command and expect failure
-          const [pushOutput] = await runVtCommand(["push"], fullPath);
+          const [pushOutput, exitCode] = await runVtCommand(["push"], fullPath);
 
           // Verify the push failed due to binary file
           assertStringIncludes(pushOutput, "binary_file.bin");
           assertStringIncludes(pushOutput, "File has binary content");
           assertStringIncludes(pushOutput, "Failed to push everything");
+          assertEquals(exitCode, 1);
         });
       });
     });


### PR DESCRIPTION
## Problem

When `vt push` fails to upload some files, it prints `! Failed to push everything` with a summary of the failures, but the process still exits 0. In CI, the step shows green and the partial deploy goes unnoticed.

Observed live today with vt 0.1.54: a push that tried to upload a `.git` directory reported 11 failed file uploads (binary pack files) and "Failed to push everything", yet exited 0.

## Fix

In `src/cmd/lib/push.ts`, when the push result has warnings (the same condition that prints "Failed to push everything"), exit with code 1. `vt pull` and `vt watch` do not share this reporting path, so they are unchanged.

Also extends the existing "push command fails with binary file" test to assert the exit code is 1 (the test helper already returned it).

## Verification

Reproduced against unmodified main by pushing a binary file from a cloned val:

Before:
```
Failures:
  A (file  ) binary_file.bin
        Error: File has binary content
...
! Failed to push everything
EXIT CODE: 0
```

After (same repro):
```
! Failed to push everything
EXIT CODE: 1
```

A fully successful push still exits 0 (verified with the same val).

`deno fmt --check` passes and `deno check src/cmd/lib/push.ts` is clean. Note that CI on main is currently red for unrelated pre-existing reasons (both test jobs failing since April; locally `deno task check` fails on a `setInterval` typing in `src/cmd/tests/utils.ts` and the cmd test suite cannot load `jsr:@valtown/sdk@2.0.0` under current Deno) — those failures are identical with and without this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/vt/pull/262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->