### PR TITLE
Release 0.1.55

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {


### PR DESCRIPTION
Bumps the version to **0.1.55** to publish the login-loop fix that just merged.

## What ships

- #261 — vt now fails fast with a clear message instead of looping the browser-login prompt forever when authentication is needed and stdin is not a terminal (the silent CI hang).

## How publishing works

`publish.yml` runs `npx jsr publish` on every push to `main`, and JSR only publishes when the `deno.json` version is new. So **merging this PR publishes 0.1.55 to JSR.** (Verified with `jsr publish --dry-run`: it succeeds on current main — JSR's slow-types check passes; the unrelated `TS2322` test-util type error fixed in #264 does not block publishing.)

The Val Town docs GitHub-sync guide will be updated to pin `jsr:@valtown/vt@0.1.55` so its workflows include this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/vt/pull/265" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->