### PR TITLE
Fail Fast Instead of Hanging on Force-Gated Confirmations When Stdin Is Not Interactive

### DIFF
--- a/src/cmd/lib/checkout.ts
+++ b/src/cmd/lib/checkout.ts
@@ -1,9 +1,8 @@
 import { Command } from "@cliffy/command";
-import { doWithSpinner } from "~/cmd/utils.ts";
+import { confirmOrExit, doWithSpinner } from "~/cmd/utils.ts";
 import VTClient from "~/vt/vt/VTClient.ts";
 import { findVtRoot } from "~/vt/vt/utils.ts";
 import { colors } from "@cliffy/ansi/colors";
-import { Confirm } from "@cliffy/prompt";
 import { tty } from "@cliffy/ansi/tty";
 import sdk, {
   branchNameToBranch,
@@ -95,14 +94,17 @@ export const checkoutCmd = new Command()
               );
             }
 
-            const shouldProceed = await Confirm.prompt({
-              message: colors.yellow(
-                currentBranchDoesntExistMsg +
-                  "It is possible that you have made changes locally since " +
-                  "the branch got deleted.\nDo you want to proceed with checkout anyway?",
-              ),
-              default: false,
-            });
+            const shouldProceed = await confirmOrExit(
+              {
+                message: colors.yellow(
+                  currentBranchDoesntExistMsg +
+                    "It is possible that you have made changes locally since " +
+                    "the branch got deleted.\nDo you want to proceed with checkout anyway?",
+                ),
+                default: false,
+              },
+              "The branch you are on no longer exists. Re-run with --force to check out anyway.",
+            );
             if (!shouldProceed) {
               console.log(skippedCheckoutMsg);
               Deno.exit(0);
@@ -229,13 +231,16 @@ export const checkoutCmd = new Command()
                 console.log();
 
                 // Ask for confirmation to proceed despite dirty state
-                const shouldProceed = await Confirm.prompt({
-                  message: colors.yellow(
-                    "Val has unpushed changes. " +
-                      "Do you want to proceed with checkout anyway?",
-                  ),
-                  default: false,
-                });
+                const shouldProceed = await confirmOrExit(
+                  {
+                    message: colors.yellow(
+                      "Val has unpushed changes. " +
+                        "Do you want to proceed with checkout anyway?",
+                    ),
+                    default: false,
+                  },
+                  "Val has unpushed changes that would be overwritten. Re-run with --force to check out anyway.",
+                );
 
                 // Exit if user doesn't want to proceed
                 if (!shouldProceed) {

--- a/src/cmd/lib/checkout.ts
+++ b/src/cmd/lib/checkout.ts
@@ -94,7 +94,7 @@ export const checkoutCmd = new Command()
               );
             }
 
-            const shouldProceed = await confirmOrExit(
+            const shouldProceed = force || await confirmOrExit(
               {
                 message: colors.yellow(
                   currentBranchDoesntExistMsg +

--- a/src/cmd/lib/pull.ts
+++ b/src/cmd/lib/pull.ts
@@ -29,8 +29,8 @@ export const pullCmd = new Command()
         const fileStateChanges = await vt.pull({ dryRun: true });
         let prepareForResult = () => {};
         if (
-          fileStateChanges.deleted.length > 0 ||
-          fileStateChanges.modified.length > 0 && !force
+          (fileStateChanges.deleted.length > 0 ||
+            fileStateChanges.modified.length > 0) && !force
         ) {
           spinner.stop();
 

--- a/src/cmd/lib/pull.ts
+++ b/src/cmd/lib/pull.ts
@@ -1,9 +1,8 @@
 import { Command } from "@cliffy/command";
-import { doWithSpinner } from "~/cmd/utils.ts";
+import { confirmOrExit, doWithSpinner } from "~/cmd/utils.ts";
 import VTClient from "~/vt/vt/VTClient.ts";
 import { findVtRoot } from "~/vt/vt/utils.ts";
 import { tty } from "@cliffy/ansi/tty";
-import { Confirm } from "@cliffy/prompt";
 import { colors } from "@cliffy/ansi/colors";
 import { displayFileStateChanges } from "~/cmd/lib/utils/displayFileStatus.ts";
 import { noChangesDryRunMsg } from "~/cmd/lib/utils/messages.ts";
@@ -50,12 +49,15 @@ export const pullCmd = new Command()
           if (dryRun) return;
 
           // Ask for confirmation to proceed despite dirty state
-          const shouldProceed = await Confirm.prompt({
-            message:
-              "There are changes being pulled that would overwrite the local state." +
-              " Are you sure you want to proceed?",
-            default: false,
-          });
+          const shouldProceed = await confirmOrExit(
+            {
+              message:
+                "There are changes being pulled that would overwrite the local state." +
+                " Are you sure you want to proceed?",
+              default: false,
+            },
+            "There are local changes that would be overwritten. Re-run with --force to pull anyway.",
+          );
           if (!shouldProceed) {
             Deno.exit(0);
           } else {

--- a/src/cmd/tests/checkout_test.ts
+++ b/src/cmd/tests/checkout_test.ts
@@ -2,7 +2,7 @@ import { doWithNewVal } from "~/vt/lib/tests/utils.ts";
 import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
-import { runVtCommand } from "~/cmd/tests/utils.ts";
+import { runVtCommand, streamVtCommand } from "~/cmd/tests/utils.ts";
 import { assert, assertStringIncludes } from "@std/assert";
 import { exists } from "@std/fs";
 import type ValTown from "@valtown/sdk";
@@ -379,32 +379,41 @@ Deno.test({
           );
         });
 
-        await t.step("checkout with warning about local changes", async () => {
-          // Try checking out to feature branch - should see warning about local changes
-          const [checkoutOutput, _] = await runVtCommand([
-            "checkout",
-            "feature",
-          ], fullPath);
+        await t.step(
+          "checkout warns and exits when stdin is not a terminal",
+          async () => {
+            // Try checking out to feature branch - because stdin is not a
+            // terminal (the test harness pipes it), the confirmation cannot be
+            // shown, so it should tell the user to re-run with --force and exit
+            // non-zero instead of hanging.
+            const [output, proc] = streamVtCommand(
+              ["checkout", "feature"],
+              fullPath,
+            );
+            const status = await proc.status;
 
-          assertStringIncludes(
-            checkoutOutput,
-            "proceed with checkout anyway",
-            "should see warning about dangerous changes",
-          );
-          assertStringIncludes(checkoutOutput, "shared.ts");
-        });
+            const text = output.join("\n");
+            assertStringIncludes(text, "shared.ts");
+            assertStringIncludes(
+              text,
+              "Re-run with --force",
+              "should tell the user to re-run with --force",
+            );
+            assert(!status.success, "checkout should exit non-zero");
+          },
+        );
 
         await t.step("force checkout overrides local changes", async () => {
           // Try with force option
           const [forceCheckoutOutput] = await runVtCommand([
             "checkout",
-            "main",
+            "feature",
             "-f",
           ], fullPath);
 
           assertStringIncludes(
             forceCheckoutOutput,
-            'Switched to branch "main"',
+            'Switched to branch "feature"',
           );
         });
       });
@@ -513,38 +522,55 @@ Deno.test({
           await sdk.vals.branches.delete(val.id, tempBranch.id);
         });
 
-        await t.step("attempt checkout after branch deletion", async () => {
-          // Try to checkout to main - should show warning about deleted branch
-          // Note that runVtCommand will spam yes to proceed
-          const [checkoutOutput, exitCode] = await runVtCommand([
-            "checkout",
-            "main",
-          ], fullPath);
+        await t.step(
+          "checkout after branch deletion warns and exits without --force",
+          async () => {
+            // Try to checkout to main without --force. Because the current
+            // branch was deleted and stdin is not a terminal (the test harness
+            // pipes it), the confirmation cannot be shown, so it should tell the
+            // user to re-run with --force and exit non-zero.
+            const [output, proc] = streamVtCommand(
+              ["checkout", "main"],
+              fullPath,
+            );
+            const status = await proc.status;
 
-          assertStringIncludes(
-            checkoutOutput,
-            "The branch you currently are no longer exists",
-            "should warn about current branch being deleted",
-          );
+            assertStringIncludes(
+              output.join("\n"),
+              "Re-run with --force",
+              "should tell the user to re-run with --force",
+            );
+            assert(!status.success, "checkout should exit non-zero");
+          },
+        );
 
-          assertStringIncludes(
-            checkoutOutput,
-            'Switched to branch "main"',
-            "should successfully switch to main branch",
-          );
+        await t.step(
+          "force checkout after branch deletion switches to main",
+          async () => {
+            const [checkoutOutput, exitCode] = await runVtCommand([
+              "checkout",
+              "main",
+              "-f",
+            ], fullPath);
 
-          assert(exitCode === 0, "checkout command should succeed");
+            assertStringIncludes(
+              checkoutOutput,
+              'Switched to branch "main"',
+              "should successfully switch to main branch",
+            );
+            assert(exitCode === 0, "checkout command should succeed");
 
-          // Verify we're now on main branch
-          const [statusOutput] = await runVtCommand(["status"], fullPath);
-          assertStringIncludes(statusOutput, "On branch main@");
+            // Verify we're now on main branch
+            const [statusOutput] = await runVtCommand(["status"], fullPath);
+            assertStringIncludes(statusOutput, "On branch main@");
 
-          // Verify main.ts exists
-          assert(
-            await exists(join(fullPath, "main.ts")),
-            "main.ts should exist after checkout to main",
-          );
-        });
+            // Verify main.ts exists
+            assert(
+              await exists(join(fullPath, "main.ts")),
+              "main.ts should exist after checkout to main",
+            );
+          },
+        );
       });
     });
   },

--- a/src/cmd/tests/pull_test.ts
+++ b/src/cmd/tests/pull_test.ts
@@ -1,9 +1,15 @@
 import { doWithNewVal } from "~/vt/lib/tests/utils.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
-import { removeAllEditorFiles, runVtCommand } from "~/cmd/tests/utils.ts";
-import { assertStringIncludes } from "@std/assert";
+import {
+  removeAllEditorFiles,
+  runVtCommand,
+  streamVtCommand,
+} from "~/cmd/tests/utils.ts";
+import { assert, assertStringIncludes } from "@std/assert";
+import { AssertionError } from "@std/assert";
 import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
+import { delay } from "@std/async";
 
 Deno.test({
   name: "pull command with no changes",
@@ -63,5 +69,71 @@ Deno.test({
       });
     });
   },
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "pull exits non-zero with a --force hint when stdin is not interactive",
+  permissions: "inherit",
+  async fn(t) {
+    await doWithTempDir(async (tmpDir) => {
+      await doWithNewVal(async ({ val, branch }) => {
+        await t.step("clone the val", async () => {
+          await runVtCommand(["clone", val.name], tmpDir);
+        });
+
+        const fullPath = join(tmpDir, val.name);
+
+        await t.step("create a tracked file", async () => {
+          await sdk.vals.files.create(val.id, {
+            path: "note.ts",
+            content: "export const x = 1;\n",
+            branch_id: branch.id,
+            type: "file",
+          });
+          await runVtCommand(["pull"], fullPath);
+        });
+
+        await t.step("diverge local and remote", async () => {
+          // Edit the file remotely...
+          await sdk.vals.files.update(val.id, {
+            path: "note.ts",
+            content: "export const x = 999;\n",
+            branch_id: branch.id,
+          });
+          // ...and locally, so a pull would overwrite local changes.
+          await Deno.writeTextFile(
+            join(fullPath, "note.ts"),
+            "export const x = 2;\n",
+          );
+        });
+
+        await t.step("pull with non-interactive stdin fails fast", async () => {
+          // streamVtCommand spawns with piped (non-TTY) stdin and never writes
+          // to it. Before the fix, the confirmation prompt would busy-loop
+          // forever instead of exiting.
+          const [output, proc] = streamVtCommand(["pull"], fullPath);
+
+          const status = await Promise.race([
+            proc.status,
+            delay(15_000).then(() => "timeout" as const),
+          ]);
+
+          if (status === "timeout") {
+            try {
+              proc.kill();
+            } catch { /* already exited */ }
+            throw new AssertionError(
+              "vt pull hung instead of failing fast on non-interactive stdin",
+            );
+          }
+
+          assert(!status.success, "expected pull to exit non-zero");
+          assertStringIncludes(output.join("\n"), "Re-run with --force");
+        });
+      });
+    });
+  },
+  sanitizeOps: false,
   sanitizeResources: false,
 });

--- a/src/cmd/utils.ts
+++ b/src/cmd/utils.ts
@@ -2,7 +2,28 @@ import ValTown from "@valtown/sdk";
 import { join } from "@std/path";
 import Kia from "kia";
 import { colors } from "@cliffy/ansi/colors";
+import { Confirm } from "@cliffy/prompt";
 import { toListBranchesCmdMsg } from "~/cmd/lib/utils/messages.ts";
+
+/**
+ * Like `Confirm.prompt`, but fails fast instead of hanging forever when stdin
+ * is not a terminal (e.g. CI, piped/closed stdin). cliffy's prompt loops on EOF
+ * and never resolves, so we surface a helpful hint and exit 1 instead.
+ *
+ * @param options Options passed through to `Confirm.prompt`
+ * @param nonInteractiveHint Message shown when stdin is not interactive
+ * @returns The user's confirmation when interactive
+ */
+export async function confirmOrExit(
+  options: Parameters<typeof Confirm.prompt>[0],
+  nonInteractiveHint: string,
+): Promise<boolean> {
+  if (!Deno.stdin.isTerminal()) {
+    console.error(colors.red(nonInteractiveHint));
+    Deno.exit(1);
+  }
+  return await Confirm.prompt(options);
+}
 
 /**
  * Determines the clone path based on the provided directory and Val name


### PR DESCRIPTION
## Problem

The `--force`-gated confirmation prompts in `vt pull` and `vt checkout` call cliffy's `Confirm.prompt` without first checking whether stdin is interactive. In a non-interactive environment (CI, scripts, anything with stdin piped or closed), the prompt's internal read loop gets EOF, treats it as no input, and re-renders forever instead of failing fast.

This is the same class of bug as #261 (the login prompt) and #260 (the org picker), at the confirmation sites that gate destructive pulls/checkouts.

The affected prompts:
- `src/cmd/lib/pull.ts` — "There are changes being pulled that would overwrite the local state. Are you sure you want to proceed?" (reached when there are local changes and `--force` was not passed).
- `src/cmd/lib/checkout.ts` — two "proceed with checkout anyway?" prompts (the current-branch-was-deleted case, and the unpushed-local-changes case).

## Evidence

Repro against `main`, on a Val whose local and remote `note.ts` have diverged (local edited, remote edited differently), with stdin closed:

```
vt pull </dev/null
```

Observed: an infinite busy-loop re-rendering the prompt — 478 KB of output in ~20 seconds and still running (had to be killed):

```
... Are you sure you want to proceed? (y/N) › ? There are changes being pulled that would overwrite the local state. Are you sure you want to proceed? (y/N) › ? There are changes being pulled that would overwrite the local state. Are you sure you want to proceed? (y/N) › ? ...
```

After the fix, the same repro exits immediately:

```
There are local changes that would be overwritten. Re-run with --force to pull anyway.
```

with exit code 1. `vt pull --force </dev/null` on the same divergent state still pulls successfully (exit 0).

## Fix

Add a small `confirmOrExit` helper in `src/cmd/utils.ts` (next to `doWithSpinner`) that mirrors the non-TTY handling introduced in #261: when `Deno.stdin.isTerminal()` is false, print a helpful hint to stderr and `Deno.exit(1)`; otherwise call `Confirm.prompt` as before. Each of the three force-gated prompts now uses `confirmOrExit` with a clear hint telling the user to re-run with `--force`.

The interactive path is unchanged — when stdin is a terminal, the prompt renders exactly as it did before.

While here, the checkout confirmation that fires when the **current branch was deleted** now also honors `--force` (it previously prompted unconditionally, ignoring the flag). This makes its "Re-run with --force" hint truthful and lets `vt checkout <branch> -f` proceed in a non-interactive shell.

## Scope

Intentionally limited to the `--force`-gated confirmations in `pull` and `checkout`. The confirmation prompts in `clone.ts` / `delete.ts` / `remix.ts` / `config.ts` have different semantics (not `--force`-gated) and are out of scope here, but the new `confirmOrExit` helper could be applied to them later in a follow-up.

## Tests

- Added a regression test in `src/cmd/tests/pull_test.ts` ("pull exits non-zero with a --force hint when stdin is not interactive"). It clones a Val, diverges local and remote copies of a tracked file, then runs `vt pull` with piped (non-TTY) stdin and asserts the process exits non-zero and prints the "Re-run with --force" hint. The test races the process against a 15 s deadline so a regression of this bug surfaces as a test failure rather than a hung suite.
- Updated the two existing `checkout_test.ts` tests that previously drove these prompts by piping "yes" to stdin ("warning on modified files" and "checkout after current branch was deleted"). They now assert the fail-fast hint + non-zero exit on non-interactive stdin, and use `--force` to actually proceed. Their non-interactive assertions read from `streamVtCommand` (which captures stderr) since the hint is written to stderr.

## Verification

- Repro above: before = infinite loop (killed); after = immediate exit 1 with the message; `--force` still pulls through.
- `deno task check` and `deno fmt --check` pass.
- `deno test ./src/cmd/tests/checkout_test.ts ./src/cmd/tests/pull_test.ts` passes (11 tests / 29 steps) locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)