### PR TITLE
Release 0.1.56

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.55",
+  "version": "0.1.56",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {


### PR DESCRIPTION
Ships #267: `vt pull` and `vt checkout` now fail fast with a "re-run with `--force`" message when stdin is not interactive, instead of hanging forever on the confirmation prompt (the same class of bug as the login-loop fixed in #261).

Merging publishes 0.1.56 to JSR via the publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/vt/pull/268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->