### PR TITLE
Reduce Flakiness in the Cmd Test Suite

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,17 @@ name: VT Testing
 on:
   push:
 
+# The cmd tests run against a single shared live test account. Running two VT
+# Testing workflows at once (e.g. two near-simultaneous merges) makes them
+# create/delete vals and stream logs concurrently, which slows the shared
+# account down and flakes the live-API tests. Serialize runs per ref so they
+# do not step on each other. We queue rather than cancel because each run's
+# tests clean up the vals they create in a `finally`; cancelling a run
+# mid-flight skips that cleanup and orphans test vals.
+concurrency:
+  group: vt-testing-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
   CI: true
 
@@ -44,7 +55,10 @@ jobs:
         uses: nick-fields/retry@v3
         with:
           command: deno task test:cmd
-          max_attempts: 2
+          # The cmd suite hits the live API and is the flakiest; allow one extra
+          # retry as a cheap backstop. Tradeoff: a genuinely-broken commit takes
+          # longer to report red, but a transient blip no longer fails the run.
+          max_attempts: 3
           timeout_seconds: 2000
         env:
           VAL_TOWN_API_KEY: ${{ secrets.VAL_TOWN_API_KEY_2 }}

--- a/src/cmd/tests/tail_test.ts
+++ b/src/cmd/tests/tail_test.ts
@@ -60,12 +60,20 @@ Deno.test({
           assert(resp.ok, "Response should be OK");
           assert(await resp.text() === "OK", "Response body should be 'OK'");
 
-          await delay(1000);
+          // Log delivery has latency (the trace has to be ingested before it
+          // can be tailed), so poll the streamed output until every expected
+          // line shows up rather than asserting after a single fixed wait.
+          const expected = [
+            "HTTP GET https://",
+            "200 main.ts",
+            "X-Custom-Header",
+          ];
+          await waitForLines(outputLines, expected);
 
           const logsOutput = outputLines.join("\n");
-          assertStringIncludes(logsOutput, "HTTP GET https://");
-          assertStringIncludes(logsOutput, "200 main.ts");
-          assertStringIncludes(logsOutput, "X-Custom-Header");
+          for (const expectedLine of expected) {
+            assertStringIncludes(logsOutput, expectedLine);
+          }
         });
       });
     });
@@ -81,4 +89,27 @@ async function waitForTailToStart(outputLines: string[]) {
     !outputLines.some((line) => line.includes("Press Ctrl+C to stop."))
   );
   await delay(1000);
+}
+
+/**
+ * Polls a growing array of output lines until every expected substring has
+ * appeared, or a deadline elapses. Returns as soon as all are present so the
+ * test stays fast in the common case while tolerating log-delivery latency.
+ *
+ * @param outputLines The array being filled by the streamed process output
+ * @param expected Substrings that must each appear somewhere in the output
+ * @param deadlineMs How long to wait before giving up (default 20s)
+ */
+async function waitForLines(
+  outputLines: string[],
+  expected: string[],
+  deadlineMs: number = 20_000,
+): Promise<void> {
+  const start = Date.now();
+  while (true) {
+    const output = outputLines.join("\n");
+    if (expected.every((line) => output.includes(line))) return;
+    if (Date.now() - start > deadlineMs) return; // let the asserts report which line is missing
+    await delay(250);
+  }
 }

--- a/src/cmd/tests/utils.ts
+++ b/src/cmd/tests/utils.ts
@@ -61,7 +61,13 @@ export async function runVtCommand(
     deadlineMs?: number;
   } = {},
 ): Promise<[string, number]> {
-  const { autoConfirm = true, deadlineMs = 8_000 } = options;
+  // The deadline is a safety net that force-kills a hung process; it is not
+  // the happy path. Commands that exit on their own (the common case, including
+  // the fail-fast non-interactive ones) are unaffected. A generous value keeps
+  // slow-but-legitimate live-API calls from being killed mid-run when the
+  // shared test account is under load, which truncates output and flakes
+  // assertions (e.g. empty captured output).
+  const { autoConfirm = true, deadlineMs = 20_000 } = options;
 
   return await doWithTempDir(async (tmpDir) => {
     const process = runVtProc(args, cwd, {

--- a/src/vt/lib/utils/misc.ts
+++ b/src/vt/lib/utils/misc.ts
@@ -60,7 +60,7 @@ export async function doAtomically<T>(
       });
     }
   } finally {
-    cleanup();
+    await cleanup();
   }
   return result;
 }


### PR DESCRIPTION
## Problem

The `test:cmd` job (the `test-mac` job in `.github/workflows/test.yaml`) flakes on live-API integration tests. The same commit fails then passes on re-run, and different tests fail across runs.

Confirmed from CI logs:

- **Run 27466506360** (`tail logs` step): failed both retry attempts with
  `Expected actual: "Tailing logs for branch main@1\nPress Ctrl+C to stop." to contain: "HTTP GET https://"`.
  The streamed log line had not been delivered within the test's single fixed `delay(1000)` window.
- **Run 27466051261** (a `runVtCommand`-driven step): failed with an assertion against **empty** captured output (`Expected actual: "" to contain: ...`). That happens when the spawned `vt` process is force-killed by the harness deadline before it can finish and print — a symptom of the shared account being slow under load.
- The two runs that triggered this work (`27466506360` and `27466499201`) were created within ~20 seconds of each other — two near-simultaneous merges competing for the single shared test account.

## Changes

| Change | Why |
| --- | --- |
| **Workflow concurrency group** (queue, not cancel) | Two `VT Testing` runs at once make both create/delete vals and stream logs against the same live account simultaneously, slowing it down and flaking the live-API tests. `concurrency: { group: vt-testing-${{ github.ref }}, cancel-in-progress: false }` serializes runs per ref. **We queue rather than cancel** on purpose: each run's tests clean up the vals they create in a `finally`; cancelling a run mid-flight skips that cleanup and orphans test vals. |
| **`tail_test.ts`: poll-until-present** | The "tail logs" step asserted the streamed log appeared after one fixed `delay(1000)`, but trace ingestion has variable latency. Replaced with a `waitForLines` helper that polls the growing output array until every expected line is present, with a generous (20s) deadline. On timeout it returns and lets the existing `assertStringIncludes` calls report exactly which line is missing — so the test verifies the same three lines, just without the fixed-wait race. |
| **`runVtCommand`: deadline 8s → 20s** | The deadline is a safety net that force-kills a *hung* process, not the happy path. Under load, legitimate-but-slow live-API calls were being killed mid-run, truncating output to empty and flaking assertions. Commands that exit on their own (including the fail-fast non-interactive tests, which exit with code 1 immediately) are unaffected. |
| **`doAtomically`: `await cleanup()`** | Temp-dir cleanup was fire-and-forget (`cleanup()` not awaited), so a `clone`/`checkout`/`pull` operation could return while its temp dir was still being torn down — racing with the next operation's temp-dir work. Awaiting it makes cleanup deterministic. |
| **Retry `max_attempts` 2 → 3** (cmd suite only) | Cheap backstop for the flakiest, live-API suite. Tradeoff: a genuinely-broken commit takes longer to report red, but a transient blip no longer fails the run. Left `test-linux` (the non-live `test:lib` suite) at 2. |

No tests were disabled or weakened — every assertion still runs and verifies the same thing.

## Verification

- `deno task check` and `deno fmt --check` are clean.
- `tail_test.ts`, `branch_test.ts`, and the lib `clone`/`checkout` tests (which exercise `doAtomically`) pass locally.
- Green-run evidence on this PR's CI is in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/vt/pull/269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->