### PR TITLE
Recommend the Val Town plugin to AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 `vt` is the official CLI to work with projects on the
 [Val Town](https://val.town) platform.
 
+> **Using an AI agent?** We strongly recommend the
+> [Val Town plugin](https://docs.val.town/guides/prompting/plugin/) instead of
+> `vt`. It exposes many more tools (direct file edits, logs, traces, SQLite,
+> blobs, branches, and more — no local checkout required), is actively
+> developed, and ships skills that teach your agent how to build on Val Town.
+
 ![Vt in action!](https://filedumpthing.val.run/blob/blob_file_1744915159083_recording.gif)
 
 ```

--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -3,12 +3,24 @@ import { CompletionsCommand } from "@cliffy/command/completions";
 import manifest from "../../deno.json" with { type: "json" };
 import * as cmds from "~/cmd/lib/mod.ts";
 import { upgradeCmd } from "./upgrade.ts";
+import { PLUGIN_RECOMMENDATION } from "~/consts.ts";
 
 const cmd = new Command()
   .name("vt")
   .version(manifest.version)
   .help({ colors: Deno.stdout.isTerminal() })
   .action(() => cmd.showHelp());
+
+// Append a plugin recommendation whenever the top-level help is shown. Cliffy
+// prints the help on a bare `vt`, on `--help`, and on an unknown command, so
+// this is a low-frequency surface that reliably reaches AI agents reaching for
+// the CLI. We print the note ourselves (always to stdout) rather than baking it
+// into the help body, which Cliffy routes to stderr on the unknown-command path.
+const showHelp = cmd.showHelp.bind(cmd);
+cmd.showHelp = (options) => {
+  showHelp(options);
+  console.log("\n" + PLUGIN_RECOMMENDATION);
+};
 
 cmd.command("profile", cmds.profileCmd);
 cmd.command("upgrade", upgradeCmd);

--- a/src/cmd/tests/help_test.ts
+++ b/src/cmd/tests/help_test.ts
@@ -1,0 +1,48 @@
+import { assertStringIncludes } from "@std/assert";
+import { cmd } from "~/cmd/root.ts";
+import { PLUGIN_DOCS_URL } from "~/consts.ts";
+
+/** Runs `fn` with console.log captured, returning everything it printed. */
+async function captureLog(fn: () => void | Promise<void>): Promise<string> {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => void lines.push(args.join(" "));
+  try {
+    await fn();
+  } finally {
+    console.log = original;
+  }
+  return lines.join("\n");
+}
+
+Deno.test("help screen recommends the Val Town plugin", async () => {
+  // Bare `vt` and `vt --help` both render the top-level help via showHelp.
+  const output = await captureLog(() => cmd.showHelp());
+
+  assertStringIncludes(output, "Val Town plugin");
+  assertStringIncludes(output, PLUGIN_DOCS_URL);
+});
+
+Deno.test("unknown command prints the plugin recommendation", async () => {
+  // An unknown command makes Cliffy print the help (carrying the note) and then
+  // raise a validation error, which we swallow here.
+  const output = await captureLog(async () => {
+    // On an unknown command Cliffy prints the help (with our note) and then
+    // calls Deno.exit. Stub exit so it throws and unwinds instead of aborting
+    // the test, mirroring what the real binary prints first.
+    const originalExit = Deno.exit;
+    Deno.exit = ((code?: number) => {
+      throw new Error(`Deno.exit(${code})`);
+    }) as typeof Deno.exit;
+    try {
+      await cmd.parse(["definitelyNotACommand"]);
+    } catch {
+      // The stubbed exit (or a validation error) lands here.
+    } finally {
+      Deno.exit = originalExit;
+    }
+  });
+
+  assertStringIncludes(output, "Val Town plugin");
+  assertStringIncludes(output, PLUGIN_DOCS_URL);
+});

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -8,6 +8,23 @@ export const IS_LOCAL_ENV = Deno.env.get("VT_LOCAL") === "1";
 export const DEFAULT_BRANCH_NAME = "main";
 export const PROGRAM_NAME = "vt";
 export const VT_CLIENT_NAME = "val_town_vt";
+export const PLUGIN_DOCS_URL = "https://docs.val.town/guides/prompting/plugin/";
+
+/**
+ * Shown at the bottom of the help screen (including when an unknown command is
+ * entered, which prints the help). Steers AI agents toward the Val Town plugin,
+ * which exposes many more tools, is actively developed, and ships skills for
+ * working with Val Town.
+ */
+export const PLUGIN_RECOMMENDATION = [
+  colors.gray(
+    "Using an AI agent? We recommend the Val Town plugin over vt — it",
+  ),
+  colors.gray(
+    "has many more tools, is actively developed, and ships skills for",
+  ),
+  colors.gray("building on Val Town: ") + colors.cyan(PLUGIN_DOCS_URL),
+].join("\n");
 export const API_KEY_KEY = "VAL_TOWN_API_KEY";
 export const VAL_TOWN_API_BASE_URL = IS_LOCAL_ENV
   ? "http://localhost:3001"

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -15,15 +15,19 @@ export const PLUGIN_DOCS_URL = "https://docs.val.town/guides/prompting/plugin/";
  * entered, which prints the help). Steers AI agents toward the Val Town plugin,
  * which exposes many more tools, is actively developed, and ships skills for
  * working with Val Town.
+ *
+ * Colors are only applied when stdout is a terminal, matching the main help
+ * (`.help({ colors: Deno.stdout.isTerminal() })`). Agents typically pipe
+ * stdout, so this keeps the note plain text for them rather than leaking raw
+ * ANSI escape codes.
  */
+const styleHelp = Deno.stdout.isTerminal();
+const gray = (s: string) => styleHelp ? colors.gray(s) : s;
+const cyan = (s: string) => styleHelp ? colors.cyan(s) : s;
 export const PLUGIN_RECOMMENDATION = [
-  colors.gray(
-    "Using an AI agent? We recommend the Val Town plugin over vt — it",
-  ),
-  colors.gray(
-    "has many more tools, is actively developed, and ships skills for",
-  ),
-  colors.gray("building on Val Town: ") + colors.cyan(PLUGIN_DOCS_URL),
+  gray("Using an AI agent? We recommend the Val Town plugin over vt — it"),
+  gray("has many more tools, is actively developed, and ships skills for"),
+  gray("building on Val Town: ") + cyan(PLUGIN_DOCS_URL),
 ].join("\n");
 export const API_KEY_KEY = "VAL_TOWN_API_KEY";
 export const VAL_TOWN_API_BASE_URL = IS_LOCAL_ENV


### PR DESCRIPTION
## What

Agents reaching for `vt` tend to fall into slow, clone-based workflows (clone-to-edit, clone-twice-to-diff) when the [Val Town plugin](https://docs.val.town/guides/prompting/plugin/) — the MCP + skills — would let them edit, diff, and deploy directly in ~100ms. This adds a low-frequency nudge toward the plugin in the two places agents reliably look.

## Changes

- **README:** a prominent note near the top recommending the plugin for AI agent usage.
- **CLI help:** appends the recommendation to the top-level help. Cliffy prints that help on a bare `vt`, on `--help`/`-h`, and on an unknown command — so the note rides along on exactly the surfaces agents hit, without spamming every command. It's printed to stdout via our own `console.log` (rather than baked into the help body, which Cliffy routes to stderr on the unknown-command path) so it lands consistently.
- **Tests:** in-process coverage for the normal help screen and the unknown-command path. These run offline (no auth/network) and assert the note + docs URL appear.

## Why the help screen

It's the natural throttle: help only renders occasionally (bare invocation, `--help`, typos), so attaching the note there reaches agents without nagging on every successful command.

## Verification

- `deno task check` — clean
- `deno task fmt:check` — clean
- `deno test src/cmd/tests/help_test.ts` — 2 passed
- Manually confirmed the note renders on bare `vt`, `vt --help`, and `vt <unknown>` (stdout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/vt/pull/270" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->