### PR TITLE
Render help and version without requiring auth

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/src/cmd/tests/authless_help_test.ts
+++ b/src/cmd/tests/authless_help_test.ts
@@ -26,6 +26,27 @@ Deno.test({
 });
 
 Deno.test({
+  // A command alias (`me` -> `profile`) is a real command, not an unknown one,
+  // so auth must NOT be skipped for it.
+  name: "command alias still requires auth",
+  permissions: "inherit",
+  async fn() {
+    await doWithTempDir(async (tmpDir) => {
+      const [output, code] = await runVtCommand(["me"], tmpDir, {
+        env: noAuthEnv,
+      });
+
+      // Auth was enforced: it fails with the invalid key rather than printing
+      // the help (which a wrongly-skipped "unknown command" path would, along
+      // with the plugin note).
+      assertEquals(code, 1);
+      assertNotMatch(output, /Val Town plugin/);
+    });
+  },
+  sanitizeResources: false,
+});
+
+Deno.test({
   name: "unknown command works without valid auth",
   permissions: "inherit",
   async fn() {

--- a/src/cmd/tests/authless_help_test.ts
+++ b/src/cmd/tests/authless_help_test.ts
@@ -1,0 +1,42 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertNotMatch } from "@std/assert";
+import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
+import { runVtCommand } from "~/cmd/tests/utils.ts";
+
+// Force an invalid key so that, if auth were NOT skipped, the command would
+// fail to authenticate and never render the help. Help appearing anyway proves
+// the help-only paths bypass auth.
+const noAuthEnv = { VAL_TOWN_API_KEY: "invalid-key-for-test" };
+
+Deno.test({
+  name: "vt --help works without valid auth",
+  permissions: "inherit",
+  async fn() {
+    await doWithTempDir(async (tmpDir) => {
+      const [output, code] = await runVtCommand(["--help"], tmpDir, {
+        env: noAuthEnv,
+      });
+
+      assertEquals(code, 0);
+      assertStringIncludes(output, "Val Town plugin");
+      assertNotMatch(output, /Authentication required/i);
+    });
+  },
+  sanitizeResources: false,
+});
+
+Deno.test({
+  name: "unknown command works without valid auth",
+  permissions: "inherit",
+  async fn() {
+    await doWithTempDir(async (tmpDir) => {
+      const [output] = await runVtCommand(["definitelyNotACommand"], tmpDir, {
+        env: noAuthEnv,
+      });
+
+      assertStringIncludes(output, "Val Town plugin");
+      assertNotMatch(output, /Authentication required/i);
+    });
+  },
+  sanitizeResources: false,
+});

--- a/vt.ts
+++ b/vt.ts
@@ -93,12 +93,40 @@ async function startVt(...args: string[]) {
   await vt.parse([...Deno.args, ...args]);
 }
 
+/**
+ * Whether the invocation only produces help or version output, which never
+ * needs a network round trip. Skipping auth for these keeps `vt`, `vt --help`,
+ * `vt --version`, and unknown/typo'd commands working (and showing the plugin
+ * recommendation) without first hitting an auth wall — which matters for agents
+ * that haven't configured a key yet.
+ */
+function isHelpOnlyInvocation(
+  args: string[],
+  knownCommands: Set<string>,
+): boolean {
+  const first = args[0];
+  if (!first) return true; // bare `vt` prints the help
+  if (["-h", "--help", "-V", "--version"].includes(first)) return true;
+  // A leading non-flag token that isn't a known command makes Cliffy print the
+  // help (and then error), so it needs no auth either.
+  if (!first.startsWith("-") && !knownCommands.has(first)) return true;
+  return false;
+}
+
 if (import.meta.main) {
   if (Deno.env.get("CI") !== "true") {
     await registerOutdatedWarning();
   }
 
-  if (!["logout"].includes(Deno.args[0])) {
+  // Importing here resolves the same cached module that startVt() uses; we read
+  // the registered command names to decide whether auth is needed.
+  const { cmd } = await import("~/cmd/root.ts");
+  const knownCommands = new Set(cmd.getCommands().map((c) => c.getName()));
+
+  if (
+    !isHelpOnlyInvocation(Deno.args, knownCommands) &&
+    !["logout"].includes(Deno.args[0])
+  ) {
     await ensureValidApiKey();
   }
 

--- a/vt.ts
+++ b/vt.ts
@@ -121,7 +121,9 @@ if (import.meta.main) {
   // Importing here resolves the same cached module that startVt() uses; we read
   // the registered command names to decide whether auth is needed.
   const { cmd } = await import("~/cmd/root.ts");
-  const knownCommands = new Set(cmd.getCommands().map((c) => c.getName()));
+  const knownCommands = new Set(
+    cmd.getCommands().flatMap((c) => [c.getName(), ...c.getAliases()]),
+  );
 
   if (
     !isHelpOnlyInvocation(Deno.args, knownCommands) &&


### PR DESCRIPTION
## What

`vt`, `vt --help`, `vt --version`, and unknown/typo'd commands only ever print help or version text — no network call needed — but they were gated behind the auth flow. So an agent (or new user) without a configured key hit an **auth wall instead of the help**, including the plugin recommendation added in #270. This skips auth for those help-only invocations.

Follow-up to #270: that PR put the plugin nudge on the help screen; this one makes sure unauthenticated agents actually reach it.

## How

A small `isHelpOnlyInvocation()` check before `ensureValidApiKey()`:
- no args (bare `vt` → help)
- `-h`/`--help`/`-V`/`--version`
- a leading non-flag token that isn't a known command (Cliffy prints help, then errors)

Known command names are read from the Cliffy command (`cmd.getCommands()`), so the list can't drift out of sync. **Real commands still authenticate exactly as before.**

## Verification

Manually, with no/invalid key:
- `vt`, `vt --help`, `vt --version`, `vt <unknown>` → render help/version (no auth wall)
- `vt list` → still prints "Authentication required" and exits

Added `authless_help_test.ts` (spawn tests forced with an invalid key, so help rendering proves auth was skipped). Runs offline:
- `deno task check` / `fmt:check` — clean
- new tests — 2 passed

Bumps to **0.1.58**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/vt/pull/272" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->