### PR TITLE
Add claude code plugin install hint

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/denoland/deno/348900b8b79f4a434cab4c74b3bc8d4d2fa8ee74/cli/schemas/config-file.v1.json",
   "name": "@valtown/vt",
   "description": "The Val Town CLI",
-  "version": "0.1.58",
+  "version": "0.1.59",
   "exports": "./vt.ts",
   "license": "MIT",
   "tasks": {

--- a/src/cmd/root.ts
+++ b/src/cmd/root.ts
@@ -3,7 +3,7 @@ import { CompletionsCommand } from "@cliffy/command/completions";
 import manifest from "../../deno.json" with { type: "json" };
 import * as cmds from "~/cmd/lib/mod.ts";
 import { upgradeCmd } from "./upgrade.ts";
-import { PLUGIN_RECOMMENDATION } from "~/consts.ts";
+import { CLAUDE_CODE_PLUGIN_HINT, PLUGIN_RECOMMENDATION } from "~/consts.ts";
 
 const cmd = new Command()
   .name("vt")
@@ -20,6 +20,16 @@ const showHelp = cmd.showHelp.bind(cmd);
 cmd.showHelp = (options) => {
   showHelp(options);
   console.log("\n" + PLUGIN_RECOMMENDATION);
+
+  // When running inside Claude Code, emit a plugin install hint on its own line
+  // to stderr. Claude Code detects this marker, strips it from the output before
+  // the model sees it, and prompts the user once to install the official Val
+  // Town plugin. It is gated on CLAUDECODE so it never reaches a human terminal,
+  // and goes to stderr so it stays out of stdout pipelines.
+  // https://code.claude.com/docs/en/plugin-hints
+  if (Deno.env.get("CLAUDECODE")) {
+    console.error(CLAUDE_CODE_PLUGIN_HINT);
+  }
 };
 
 cmd.command("profile", cmds.profileCmd);

--- a/src/cmd/tests/help_test.ts
+++ b/src/cmd/tests/help_test.ts
@@ -1,18 +1,44 @@
-import { assertStringIncludes } from "@std/assert";
+import {
+  assertArrayIncludes,
+  assertEquals,
+  assertStringIncludes,
+} from "@std/assert";
 import { cmd } from "~/cmd/root.ts";
-import { PLUGIN_DOCS_URL } from "~/consts.ts";
+import { CLAUDE_CODE_PLUGIN_HINT, PLUGIN_DOCS_URL } from "~/consts.ts";
 
-/** Runs `fn` with console.log captured, returning everything it printed. */
-async function captureLog(fn: () => void | Promise<void>): Promise<string> {
+/** Runs `fn` with `console[method]` captured, returning everything it printed. */
+async function capture(
+  method: "log" | "error",
+  fn: () => void | Promise<void>,
+): Promise<string> {
   const lines: string[] = [];
-  const original = console.log;
-  console.log = (...args: unknown[]) => void lines.push(args.join(" "));
+  const original = console[method];
+  console[method] = (...args: unknown[]) => void lines.push(args.join(" "));
   try {
     await fn();
   } finally {
-    console.log = original;
+    console[method] = original;
   }
   return lines.join("\n");
+}
+
+/** Runs `fn` with console.log captured, returning everything it printed. */
+const captureLog = (fn: () => void | Promise<void>) => capture("log", fn);
+
+/** Runs `fn` with the CLAUDECODE env var set to `value` (restored afterward). */
+async function withClaudeCode<T>(
+  value: string | undefined,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  const original = Deno.env.get("CLAUDECODE");
+  if (value === undefined) Deno.env.delete("CLAUDECODE");
+  else Deno.env.set("CLAUDECODE", value);
+  try {
+    return await fn();
+  } finally {
+    if (original === undefined) Deno.env.delete("CLAUDECODE");
+    else Deno.env.set("CLAUDECODE", original);
+  }
 }
 
 Deno.test("help screen recommends the Val Town plugin", async () => {
@@ -21,6 +47,25 @@ Deno.test("help screen recommends the Val Town plugin", async () => {
 
   assertStringIncludes(output, "Val Town plugin");
   assertStringIncludes(output, PLUGIN_DOCS_URL);
+});
+
+Deno.test("emits the Claude Code plugin hint when running inside Claude Code", async () => {
+  const errors = await withClaudeCode(
+    "1",
+    () => capture("error", () => cmd.showHelp()),
+  );
+
+  // The hint must be on its own line for Claude Code to act on it.
+  assertArrayIncludes(errors.split("\n"), [CLAUDE_CODE_PLUGIN_HINT]);
+});
+
+Deno.test("omits the plugin hint outside Claude Code", async () => {
+  const errors = await withClaudeCode(
+    undefined,
+    () => capture("error", () => cmd.showHelp()),
+  );
+
+  assertEquals(errors.includes("claude-code-hint"), false);
 });
 
 Deno.test("unknown command prints the plugin recommendation", async () => {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -29,6 +29,21 @@ export const PLUGIN_RECOMMENDATION = [
   gray("has many more tools, is actively developed, and ships skills for"),
   gray("building on Val Town: ") + cyan(PLUGIN_DOCS_URL),
 ].join("\n");
+
+/** The Val Town plugin's identifier (name@marketplace) in the official Anthropic marketplace. */
+export const CLAUDE_CODE_PLUGIN_ID = "valtown@claude-plugins-official";
+
+/**
+ * Claude Code plugin hint. When `vt` runs inside Claude Code (detected via the
+ * CLAUDECODE env var), printing this self-closing marker on its own line to
+ * stderr prompts the user — once — to install the official Val Town plugin.
+ * Claude Code strips the line from the output before it reaches the model, so
+ * it never appears in the conversation and is not counted toward token usage.
+ *
+ * See https://code.claude.com/docs/en/plugin-hints.
+ */
+export const CLAUDE_CODE_PLUGIN_HINT =
+  `<claude-code-hint v="1" type="plugin" value="${CLAUDE_CODE_PLUGIN_ID}" />`;
 export const API_KEY_KEY = "VAL_TOWN_API_KEY";
 export const VAL_TOWN_API_BASE_URL = IS_LOCAL_ENV
   ? "http://localhost:3001"


### PR DESCRIPTION
Per https://code.claude.com/docs/en/plugin-hints this adds a hint to prompt claude code to install the plugin if it runs `vt --help`

<img width="1250" height="423" alt="Screenshot 2026-06-18 at 3 27 06 PM" src="https://github.com/user-attachments/assets/dc596901-6a41-4dc9-90ea-546b5049aff2" />
