### PR TITLE
Store branch name in `vt` state

### DIFF
--- a/src/cmd/lib/checkout.ts
+++ b/src/cmd/lib/checkout.ts
@@ -144,11 +144,6 @@ export const checkoutCmd = new Command()
               },
             );
 
-            // Note that if they try to check out to the same branch, we can't
-            // even figure that out, because we store the branch ID, not the
-            // branch name. So this warning, while useful, won't show up if they
-            // are checking out FROM a branch that has been deleted and currently
-            // does not exist.
             if (currentBranchData.name === branchName) {
               spinner.warn(
                 `You are already on branch "${dryCheckoutResult.fromBranch.name}"`,

--- a/src/cmd/lib/clone.ts
+++ b/src/cmd/lib/clone.ts
@@ -112,6 +112,7 @@ export const cloneCmd = new Command()
           rootPath: clonePath,
           valName,
           username: ownerName,
+          branchName,
         });
 
         if (editorFiles) {

--- a/src/cmd/tests/checkout_test.ts
+++ b/src/cmd/tests/checkout_test.ts
@@ -2,8 +2,12 @@ import { doWithNewVal } from "~/vt/lib/tests/utils.ts";
 import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { join } from "@std/path";
 import sdk from "~/sdk.ts";
-import { runVtCommand, streamVtCommand } from "~/cmd/tests/utils.ts";
-import { assert, assertStringIncludes } from "@std/assert";
+import {
+  readPersistedBranchName,
+  runVtCommand,
+  streamVtCommand,
+} from "~/cmd/tests/utils.ts";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { exists } from "@std/fs";
 import type ValTown from "@valtown/sdk";
 
@@ -50,6 +54,12 @@ Deno.test({
             tmpDir,
           );
 
+          assertEquals(
+            await readPersistedBranchName(fullPath),
+            "main",
+            "clone should persist the checked-out branch name",
+          );
+
           // Make a remote change to main branch after cloning
           await sdk.vals.files.update(
             val.id,
@@ -83,6 +93,12 @@ Deno.test({
           assert(
             await exists(join(fullPath, "feature.ts")),
             "feature.ts should exist after checkout; we're not on feature branch",
+          );
+
+          assertEquals(
+            await readPersistedBranchName(fullPath),
+            "feature-branch",
+            "checkout should persist the target branch name",
           );
 
           const [statusOutput] = await runVtCommand(["status"], fullPath);
@@ -146,6 +162,12 @@ Deno.test({
           assertStringIncludes(
             checkoutOutput,
             'Created and switched to new branch "feature-with-changes"',
+          );
+
+          assertEquals(
+            await readPersistedBranchName(fullPath),
+            "feature-with-changes",
+            "checkout -b should persist the new branch name",
           );
         });
 

--- a/src/cmd/tests/clone_test.ts
+++ b/src/cmd/tests/clone_test.ts
@@ -8,6 +8,7 @@ import {
 import { exists } from "@std/fs";
 import { join } from "@std/path";
 import {
+  readPersistedBranchName,
   runVtCommand,
   streamVtCommand,
   waitForStable,
@@ -15,6 +16,7 @@ import {
 import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import sdk, { getCurrentUser, randomValName } from "~/sdk.ts";
 import type { ValFileType } from "~/types.ts";
+import { DEFAULT_BRANCH_NAME } from "~/consts.ts";
 
 Deno.test({
   name: "clone preserves custom deno.json and .vtignore",
@@ -129,6 +131,12 @@ Deno.test({
           ], tmpDir);
           assertStringIncludes(output, "cloned to");
 
+          assertEquals(
+            await readPersistedBranchName(cloneDir),
+            DEFAULT_BRANCH_NAME,
+            "clone should persist the checked-out branch name",
+          );
+
           // Verify the files exist
           const testJsExists = await exists(join(cloneDir, "test.js"));
           assertEquals(testJsExists, true, "test.js should exist");
@@ -146,6 +154,29 @@ Deno.test({
             innerContent,
             "export function test() { return 'Hello from test_inner'; }",
             "content of test_inner.js should match",
+          );
+        });
+
+        await t.step("clone a non-default branch", async () => {
+          const branchName = "feature-branch";
+          await sdk.vals.branches.create(
+            val.id,
+            { name: branchName, branchId: branch.id },
+          );
+
+          const cloneDir = join(tmpDir, "feature-clone");
+          await runVtCommand([
+            "clone",
+            val.name,
+            cloneDir,
+            branchName,
+            "--no-editor-files",
+          ], tmpDir);
+
+          assertEquals(
+            await readPersistedBranchName(cloneDir),
+            branchName,
+            "clone should persist a non-default checked-out branch name",
           );
         });
       });

--- a/src/cmd/tests/create_test.ts
+++ b/src/cmd/tests/create_test.ts
@@ -15,7 +15,11 @@ import sdk, {
   listValItems,
   randomValName,
 } from "~/sdk.ts";
-import { runVtCommand, streamVtCommand } from "~/cmd/tests/utils.ts";
+import {
+  readPersistedBranchName,
+  runVtCommand,
+  streamVtCommand,
+} from "~/cmd/tests/utils.ts";
 import { DEFAULT_BRANCH_NAME } from "~/consts.ts";
 import { delay } from "@std/async";
 
@@ -111,6 +115,12 @@ Deno.test({
           assert(
             await exists(join(tmpDir, newValName)),
             "val was not cloned to target",
+          );
+
+          assertEquals(
+            await readPersistedBranchName(join(tmpDir, newValName)),
+            DEFAULT_BRANCH_NAME,
+            "create should persist the initial branch name",
           );
         });
       });

--- a/src/cmd/tests/remix_test.ts
+++ b/src/cmd/tests/remix_test.ts
@@ -1,10 +1,10 @@
 import { doWithNewVal } from "~/vt/lib/tests/utils.ts";
 import { join } from "@std/path";
 import sdk, { getCurrentUser } from "~/sdk.ts";
-import { runVtCommand } from "~/cmd/tests/utils.ts";
-import { assert, assertStringIncludes } from "@std/assert";
+import { readPersistedBranchName, runVtCommand } from "~/cmd/tests/utils.ts";
+import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import { exists } from "@std/fs";
-import { META_FOLDER_NAME } from "~/consts.ts";
+import { DEFAULT_BRANCH_NAME, META_FOLDER_NAME } from "~/consts.ts";
 import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 
 Deno.test({
@@ -43,6 +43,12 @@ Deno.test({
           assert(
             await exists(join(remixedValPath, META_FOLDER_NAME)),
             "remixed Val should have .vt metadata folder",
+          );
+
+          assertEquals(
+            await readPersistedBranchName(remixedValPath),
+            DEFAULT_BRANCH_NAME,
+            "remix should persist the initial branch name",
           );
         });
 

--- a/src/cmd/tests/utils.ts
+++ b/src/cmd/tests/utils.ts
@@ -1,7 +1,12 @@
 import { join, relative } from "@std/path";
 import { walk } from "@std/fs";
 import stripAnsi from "strip-ansi";
-import { DEFAULT_BRANCH_NAME, DEFAULT_EDITOR_TEMPLATE } from "~/consts.ts";
+import {
+  DEFAULT_BRANCH_NAME,
+  DEFAULT_EDITOR_TEMPLATE,
+  META_FOLDER_NAME,
+  META_STATE_FILE_NAME,
+} from "~/consts.ts";
 import sdk, {
   branchNameToBranch,
   getCurrentUser,
@@ -40,6 +45,21 @@ export function runVtProc(
   });
 
   return command.spawn();
+}
+
+/**
+ * Reads the branch name persisted in a Val's local VT state file.
+ */
+export async function readPersistedBranchName(
+  rootPath: string,
+): Promise<string | undefined> {
+  const state = JSON.parse(
+    await Deno.readTextFile(
+      join(rootPath, META_FOLDER_NAME, META_STATE_FILE_NAME),
+    ),
+  ) as { branch: { name?: string } };
+
+  return state.branch.name;
 }
 
 /**

--- a/src/cmd/tests/utils.ts
+++ b/src/cmd/tests/utils.ts
@@ -1,12 +1,7 @@
 import { join, relative } from "@std/path";
 import { walk } from "@std/fs";
 import stripAnsi from "strip-ansi";
-import {
-  DEFAULT_BRANCH_NAME,
-  DEFAULT_EDITOR_TEMPLATE,
-  META_FOLDER_NAME,
-  META_STATE_FILE_NAME,
-} from "~/consts.ts";
+import { DEFAULT_BRANCH_NAME, DEFAULT_EDITOR_TEMPLATE } from "~/consts.ts";
 import sdk, {
   branchNameToBranch,
   getCurrentUser,
@@ -17,6 +12,7 @@ import { ENTRYPOINT_NAME } from "~/consts.ts";
 import { doWithTempDir } from "~/vt/lib/utils/misc.ts";
 import { parseValUri } from "~/cmd/lib/utils/parsing.ts";
 import { delay } from "@std/async";
+import VTMeta from "~/vt/vt/VTMeta.ts";
 
 /**
  * Creates and spawns a Deno child process for the vt.ts script.
@@ -53,13 +49,7 @@ export function runVtProc(
 export async function readPersistedBranchName(
   rootPath: string,
 ): Promise<string | undefined> {
-  const state = JSON.parse(
-    await Deno.readTextFile(
-      join(rootPath, META_FOLDER_NAME, META_STATE_FILE_NAME),
-    ),
-  ) as { branch: { name?: string } };
-
-  return state.branch.name;
+  return (await new VTMeta(rootPath).loadVtState()).branch.name;
 }
 
 /**

--- a/src/vt/vt/VTClient.ts
+++ b/src/vt/vt/VTClient.ts
@@ -140,7 +140,7 @@ export default class VTClient {
 
     await vt.getMeta().saveVtState({
       val: { id: valId },
-      branch: { id: branch.id, version: version },
+      branch: { id: branch.id, name: branch.name, version: version },
     });
 
     return vt;
@@ -427,7 +427,7 @@ export default class VTClient {
     // Save the VT state
     await vt.getMeta().saveVtState({
       val: { id: valId },
-      branch: { id: branch.id, version },
+      branch: { id: branch.id, name: branch.name, version },
     });
 
     // Perform the clone
@@ -608,6 +608,7 @@ export default class VTClient {
         if (!baseParams.dryRun) {
           if (result.toBranch) {
             vtState.branch.id = result.toBranch.id;
+            vtState.branch.name = result.toBranch.name;
             vtState.branch.version = FIRST_VERSION_NUMBER; // Set version to 1 for the new branch
           }
         }
@@ -637,6 +638,7 @@ export default class VTClient {
       if (!baseParams.dryRun) {
         if (result.toBranch) {
           vtState.branch.id = result.toBranch.id;
+          vtState.branch.name = result.toBranch.name;
           vtState.branch.version = result.toBranch.version; // Use the target branch's version
         }
       }

--- a/src/vt/vt/schemas.ts
+++ b/src/vt/vt/schemas.ts
@@ -32,6 +32,14 @@ export const VTStateSchema = z
       .catch({ id: "" }),
     branch: z.object({
       id: z.string().uuid(),
+      // Store the exact Val Town branch name in JSON so shell prompts and
+      // other local tooling can read it without making an API call.
+      //
+      // Keep this optional so existing checkouts created before this field was
+      // added continue to load; new state writes populate it whenever the
+      // branch is known. JSON.stringify will safely escape control characters
+      // if a branch name is displayed by bash/zsh prompt integrations.
+      name: z.string().optional(),
       version: z.number().gte(0),
     }),
     lastRun: z.object({


### PR DESCRIPTION
## Summary

- Persist the checked-out branch name in `.vt/state.json`.
- Update it after create/remix, clone, checkout, and `checkout -b`.
- Keep the field optional so existing local state stays compatible.
- Add regression coverage for every state-writing path.

## Why

Local tooling, including shell prompts, can determine the active Val Town branch without an API call.

## Validation

- `deno task check`
- Targeted command tests covering create, remix, clone, checkout, and `checkout -b`
- Manual smoke test of `.vt/state.json` after clone and checkout